### PR TITLE
Use wss: scheme when connection is secure.

### DIFF
--- a/javascript/util/node/web_socket.js
+++ b/javascript/util/node/web_socket.js
@@ -28,7 +28,8 @@ Faye.WebSocket = Faye.Class({
     this._head    = head;
     this._stream  = request.socket;
     
-    this.url = 'ws://' + request.headers.host + request.url;
+    var scheme = request.socket.secure ? 'wss:' : 'ws:';
+    this.url = scheme + '//' + request.headers.host + request.url;    
     this.readyState = Faye.WebSocket.CONNECTING;
     this.bufferedAmount = 0;
     


### PR DESCRIPTION
It is not possible to setup a WebSocket connection using SSL in the current master. This is because the server-side WebSocket implementation hardcodes the scheme for the WebSocket handshake to 'ws:'. Even when there is a secure socket connection.

This results in a failed WebSocket connection and Chrome printing something like: "Error during WebSocket handshake: location mismatch: wss://host/faye != ws://host/faye"

This commit fixes this by using 'wss:' as scheme if request.socket.secure is set to true. 
