### PR TITLE
Use wss: scheme when connection to reverse proxy is secure

### DIFF
--- a/javascript/util/node/web_socket.js
+++ b/javascript/util/node/web_socket.js
@@ -28,7 +28,7 @@ Faye.WebSocket = Faye.Class({
     this._head    = head;
     this._stream  = request.socket;
     
-    var scheme = request.socket.secure ? 'wss:' : 'ws:';
+    var scheme = Faye.WebSocket.isSecureConnection(request) ? 'wss:' : 'ws:';
     this.url = scheme + '//' + request.headers.host + request.url;    
     this.readyState = Faye.WebSocket.CONNECTING;
     this.bufferedAmount = 0;
@@ -130,6 +130,14 @@ Faye.extend(Faye.WebSocket, {
     return (headers['sec-websocket-key1'] && headers['sec-websocket-key2'])
          ? this.Protocol76
          : this.Protocol75;
+  },
+  
+  isSecureConnection: function(request) {
+    if (request.headers['x-forwarded-proto']) {
+      return request.headers['x-forwarded-proto'] == 'https';
+    } else {
+      return request.socket.secure;
+    }
   }
 });
 


### PR DESCRIPTION
When using a reverse proxy to do the SSL heavy lifting, the proxy will talk plain http to Faye. 

In order to return the correct WebSocket-Location, Faye needs to know if the original request (between browser and proxy) was secure or not.

This commit fixes this by respecting the X-Forwarded-Proto http header. 
