### PR TITLE
Support em-http-request 1.0 timeouts

### DIFF
--- a/lib/faye/network/transport.rb
+++ b/lib/faye/network/transport.rb
@@ -1,4 +1,5 @@
 require 'em-http'
+require 'em-http/version'
 require 'json'
 require 'uri'
 
@@ -82,9 +83,16 @@ module Faye
           'Content-Length'  => content.length
         },
         :body    => content,
-        :timeout => -1
+        :timeout => -1  # for em-http-request < 1.0
       }
-      request = EventMachine::HttpRequest.new(@endpoint).post(params)
+      if EventMachine::HttpRequest::VERSION.split('.')[0].to_i >= 1
+        options = {   # for em-http-request >= 1.0
+          :inactivity_timeout => 0,    # connection inactivity (post-setup) timeout (0 = disable timeout)
+        }
+        request = EventMachine::HttpRequest.new(@endpoint, options).post(params)
+      else
+        request = EventMachine::HttpRequest.new(@endpoint).post(params)
+      end
       request.callback do
         begin
           receive(JSON.parse(request.response))


### PR DESCRIPTION
em-http-request 1.0 changes how http timeouts are specified.  This changeset allows Faye::HttpTransport to work with both 1.0 and < 1.0
