### PR TITLE
Workaround for XDomainRequest bug in Internet Explorer 9.

### DIFF
--- a/javascript/transport/cors.js
+++ b/javascript/transport/cors.js
@@ -18,6 +18,7 @@ Faye.Transport.CORS = Faye.extend(Faye.Class(Faye.Transport, {
       }
     };
     xhr.onerror = retry;
+    xhr.onprogress = function() {};
     xhr.send('message=' + encodeURIComponent(Faye.toJSON(message)));
   }
 }), {


### PR DESCRIPTION
Here is a pull request for the one-liner. ;-)
Fixes CORS support for IE9.
