### PR TITLE
Fix for test/plain processing in rack adapter

### DIFF
--- a/lib/faye/adapters/rack_adapter.rb
+++ b/lib/faye/adapters/rack_adapter.rb
@@ -2,6 +2,7 @@ require 'rubygems'
 require 'json'
 require 'rack'
 require 'thin'
+require 'cgi'
 require Faye::ROOT + '/thin_extensions'
 
 module Faye
@@ -99,9 +100,13 @@ module Faye
     def message_from_request(request)
       if request.post?
         content_type = request.env['CONTENT_TYPE'].split(';').first
-        content_type == 'application/json' ?
-            request.body.read :
-            request.params['message']
+        if content_type == 'application/json'
+          request.body.read
+        elsif content_type == 'text/plain'
+          CGI.parse(request.body.read)['message'][0]
+        else
+          request.params['message']
+        end
       else
         request.params['message']
       end

--- a/spec/ruby/rack_adapter_spec.rb
+++ b/spec/ruby/rack_adapter_spec.rb
@@ -58,6 +58,45 @@ describe Faye::RackAdapter do
         content_type.should == "text/plain"
       end
     end
+
+    describe "with text/plain" do
+      before do
+        header "Content-Type", "text/plain"
+      end
+
+      it "forwards the POST body onto the server" do
+        server.should_receive(:process).with({"channel" => "/plain"}, false).and_yield []
+        post "/bayeux", "message=%7B%22channel%22%3A%22%2Fplain%22%7D"
+      end
+
+      it "does not return an access control header" do
+        server.stub(:process).and_yield []
+        post "/bayeux", 'message=%5B%5D'
+        access_control_origin.should be_nil
+      end
+
+      it "returns the server's response as JSON" do
+        server.stub(:process).and_yield ["channel" => "/meta/handshake"]
+        post "/bayeux", 'message=%5B%5D'
+        status.should == 200
+        content_type.should == "application/json"
+        json.should == ["channel" => "/meta/handshake"]
+      end
+
+      it "returns a 400 response if malformed JSON is given" do
+        server.should_not_receive(:process)
+        post "/bayeux", "message=%7B%5B"
+        status.should == 400
+        content_type.should == "text/plain"
+      end
+
+      it "returns a 404 if the path is not matched" do
+        server.should_not_receive(:process)
+        post "/blaf", 'message=%5B%5D'
+        status.should == 404
+        content_type.should == "text/plain"
+      end
+    end
     
     describe "with application/json" do
       before do


### PR DESCRIPTION
Fixes issue #58.  The problem is that the server isn't parsing the request body into a parameters hash when the content type is text/plain.  I added some manual parsing by using CGI.parse.

I copied the application/json tests and made them into text/plain tests, passing in the specific encoded values that the browser would pass in.

I had some problems running the full test suite, although I don't think that's related to this change.  First of all, the engine_spec.rb test runs at 100% cpu for a long time.  I eventually killed it after 20 minutes.

Second, the handshake_spec.rb file fails in a few places.  I think its because the spec just needs to be updated to include "in-process" as one of the supportedConnectionTypes, but I wasn't sure so I didn't change it.
