### PR TITLE
Added :auth option to Redis engine.

### DIFF
--- a/javascript/engines/redis.js
+++ b/javascript/engines/redis.js
@@ -9,10 +9,16 @@ Faye.Engine.Redis = Faye.Class(Faye.Engine.Base, {
     
     var redis = require('redis'),
         host  = this._options.host || this.DEFAULT_HOST,
-        port  = this._options.port || this.DEFAULT_PORT;
+        port  = this._options.port || this.DEFAULT_PORT,
+        auth  = this._options.auth;
     
     this._redis = redis.createClient(port, host);
     this._subscriber = redis.createClient(port, host);
+    
+    if (auth) {
+      this._redis.auth(auth);
+      this._subscriber.auth(auth);
+    }
     
     var self = this;
     this._subscriber.subscribe('/notifications');

--- a/lib/faye/engines/redis.rb
+++ b/lib/faye/engines/redis.rb
@@ -11,9 +11,11 @@ module Faye
         
         host = @options[:host] || DEFAULT_HOST
         port = @options[:port] || DEFAULT_PORT
+        auth = @options[:auth] ? "#{@options[:auth]}@" : ''
+        url = "redis://#{auth}#{host}:#{port}"
         
-        @redis      = EventMachine::Hiredis::Client.connect(host, port)
-        @subscriber = EventMachine::Hiredis::Client.connect(host, port)
+        @redis      = EventMachine::Hiredis.connect(ENV['REDIS_URL'] || url)
+        @subscriber = EventMachine::Hiredis.connect(ENV['REDIS_URL'] || url)
         
         @subscriber.subscribe('/notifications')
         @subscriber.on(:message) do |topic, message|


### PR DESCRIPTION
This patch allows the use of a remote Redis server.
Using it I've successfully deployed the Ruby Faye server on Heroku and RedisToGo.
Though the tests pass, I haven't tested the Node server in real conditions.
Thanks for a great lib!
