### PR TITLE
Websocket detection of original request SSL mode failed. Fixed for node 0.4.8.

### DIFF
--- a/javascript/util/node/web_socket.js
+++ b/javascript/util/node/web_socket.js
@@ -136,7 +136,7 @@ Faye.extend(Faye.WebSocket, {
     if (request.headers['x-forwarded-proto']) {
       return request.headers['x-forwarded-proto'] == 'https';
     } else {
-      return request.socket.secure;
+      return typeof(request.connection.authorized) != 'undefined';
     }
   }
 });


### PR DESCRIPTION
Websocket detection of original request SSL mode failed. Fixed for node 0.4.8.

Note I don't know if this is "clean", but found no other way in the API docs to detect a SSL connection from a request object.
