### PR TITLE
Allow usage of EventMachine 1.0.0

### DIFF
--- a/faye.gemspec
+++ b/faye.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
                         Dir.glob("{spec,lib}/**/*")
   s.require_paths     = ["lib"]
 
-  s.add_dependency("eventmachine", "~> 0.12.0")
+  s.add_dependency("eventmachine", ">= 0.12.0")
   s.add_dependency("em-http-request", ">= 0.2")
   s.add_dependency("em-hiredis", ">= 0.0.1")
   s.add_dependency("json", ">= 1.0")


### PR DESCRIPTION
Faye works great with EventMachine 1.0.0.beta so relaxed the required version for the eventmachine dependency. 
