### PR TITLE
Example of node_http transport with new https module, and a naiive cookie implementation

### DIFF
--- a/javascript/adapters/node_adapter.js
+++ b/javascript/adapters/node_adapter.js
@@ -3,6 +3,7 @@ var path  = require('path'),
     sys   = require('sys'),
     url   = require('url'),
     http  = require('http'),
+    https = require('https'),
     querystring = require('querystring');
 
 Faye.logger = function(message) {

--- a/javascript/transport/node_http.js
+++ b/javascript/transport/node_http.js
@@ -1,28 +1,67 @@
 Faye.Transport.NodeHttp = Faye.extend(Faye.Class(Faye.Transport, {
-  request: function(message, timeout) {
+  request: function(message, timeout) {        
     var uri      = url.parse(this._endpoint),
         secure   = (uri.protocol === 'https:'),
         port     = (secure ? 443 : 80),
-        client   = http.createClient(uri.port || port, uri.hostname, secure),
+        client   = (secure ? https : http),
         content  = JSON.stringify(message),
         response = null,
         retry    = this.retry(message, timeout),
         self     = this;
+        
+    //Custom cookie implementation.
+    //Expecting cookies to be set in an object called ext.cookies from an outbound extension 
+    this._client.cookies  =  this._client.cookies || {};
+    this._client.cookies.__proto__.toString = function(){
+        var retString = "";
+        for(var key in this){
+            retString += key + "=" + this[key] + "; ";
+        }
+        return retString;
+    }
+
+    //ghetto deep copy
+    for(attrname in message[0].ext.cookies){ this._client.cookies[attrname] = message[0].ext.cookies[attrname]} //"message" is an array...
     
-    client.addListener('error', retry);
+    var cookieString = this._client.cookies.toString();
+    var options = {
+      host: uri.hostname,
+      port: port,
+      method: 'POST',
+      path: uri.pathname,
+      headers:{
+        'Content-Type':   'application/json',
+        'Host':           uri.hostname,
+        'Content-Length': content.length,
+        'Cookie': cookieString
+      }
+    };
+        
+    var request = client.request(options);
     
-    client.addListener('end', function() {
-      if (!response) retry();
+    request.on('error', retry);
+    
+    request.on('error', function(error){
+        console.log("Request error: " + error);
     });
     
-    var request = client.request('POST', uri.pathname, {
-      'Content-Type':   'application/json',
-      'Host':           uri.hostname,
-      'Content-Length': content.length
-    });
-    
-    request.addListener('response', function(stream) {
+    request.on('response', function(stream) {
       response = stream;
+      
+      //naive cookie implementation.  Grab cookies from set-cookie header and do some splitting and stuff
+      var headerArray = response.headers['set-cookie'];
+      if(headerArray){
+          for(var j = 0; j < headerArray.length; j++){
+
+              var pair = headerArray[j].split(';');         
+              //pair of cookie keyvalues ie something=thing
+              for(var i = 0; i < pair.length; i++){      
+                  var parts = pair[i].split('=');
+                  self._client.cookies[ parts[ 0 ].trim() ] = ( parts[ 1 ] || '' ).trim();  //0 is key, 1 is val
+              }              
+          }
+      }
+      
       Faye.withDataFor(response, function(data) {
         try {
           self.receive(JSON.parse(data));
@@ -34,6 +73,7 @@ Faye.Transport.NodeHttp = Faye.extend(Faye.Class(Faye.Transport, {
     
     request.write(content);
     request.end();
+    
   }
 }), {
   isUsable: function(endpoint, callback, scope) {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 , "keywords"      : ["comet", "websocket", "pubsub", "bayeux", "ajax", "http"]
 
 , "version"       : "0.6.3"
-, "engines"       : {"node": ">=0.1.96"}
+, "engines"       : {"node": ">=0.3.6"}
 , "main"          : "./faye-node"
 , "dependencies"  : {"redis": ""}
 


### PR DESCRIPTION
Hi James,

I've modified faye a little bit so that it works with the newer https library.  This was changed somewhere in node 0.3.6 I think.

I also added a basic naiive implementation for cookies, making it a Cookie-Enabled Bayeux client, like the one from the CometD libraries.  It's a bit hack-ish at best, it might be better refactored into a nicer Cookie class or something.

I just wanted to get your eyes on this to see what you thought, if you'd like I can create a totally different branch for this.  @metadaddy and I have been playing around with Faye to connect it to the new Salesforce Streaming API (there's another hack-ish commit that I have in my fork which I haven't included in this pull request).

Also sorry if this comes off as presumptuous, I'm not assuming that you'll accept this into your master branch right away or anything.  I wouldn't mind putting this in another branch though, as HTTPS/Cookies are useful features to people who want to connect the Faye Client to a non-Faye server! :)

Cheers!
