### PR TITLE
Fix for Redis ERR Operation against a key holding the wrong kind of value

### DIFF
--- a/javascript/engines/redis.js
+++ b/javascript/engines/redis.js
@@ -137,7 +137,6 @@ Faye.Engine.Redis = Faye.Class(Faye.Engine.Base, {
     this._redis.lrange(key, 0, -1, function(error, jsonMessages) {
       self._redis.ltrim(key, jsonMessages.length, -1);
       Faye.each(jsonMessages, function(jsonMessage) {
-        self._redis.srem(key, jsonMessage);
         conn.deliver(JSON.parse(jsonMessage));
       });
     });


### PR DESCRIPTION
Removed srem in emptyQueue() - Leftover from set -> list transition in commit 
https://github.com/jcoglan/faye/commit/4cfd849404fb1516a1488279418b91e5607f7fd9

Please let me know if you have any questions. Looks like you just missed a line in the Javascript redis engine. Appears you made the correct fix in the Ruby redis engine.

Thanks for the library. Tis a thing of beauty!

-jonathan
