### PR TITLE
Check ontimeout for IE9 in IE8 comp. mode

### DIFF
--- a/javascript/transport/cors.js
+++ b/javascript/transport/cors.js
@@ -18,6 +18,7 @@ Faye.Transport.CORS = Faye.extend(Faye.Class(Faye.Transport, {
       }
     };
     xhr.onerror = retry;
+    xhr.ontimeout = retry;
     xhr.onprogress = function() {};
     xhr.send('message=' + encodeURIComponent(Faye.toJSON(message)));
   }


### PR DESCRIPTION
IE9 in IE8 compatibility mode makes difference between onerror and ontimeout events for XmlHttpRequest/XDomainRequest. retry event should be tied to both.
