### PR TITLE
Browser faye doesn't connect over https

### DIFF
--- a/javascript/util/browser/uri.js
+++ b/javascript/util/browser/uri.js
@@ -39,7 +39,7 @@ Faye.URI = Faye.extend(Faye.Class({
     consume('port',     /^:[0-9]+/);
     
     Faye.extend(location, {
-      protocol:   'http://',
+      protocol:   Faye.ENV.location.protocol + '//',
       hostname:   Faye.ENV.location.hostname,
       port:       Faye.ENV.location.port
     }, false);


### PR DESCRIPTION
When using https, faye tries to connects with callback-polling to http://myhost instead of to https://myhost with long-polling.

I admit that don't exactly understand what's going on here or what other things this might impact. 

I'm unable to run the test suite due to the missing em-rspec.. :/
