### PR TITLE
Allow connecting thru a unix socket for redis clients in redis engine

### DIFF
--- a/javascript/engines/redis.js
+++ b/javascript/engines/redis.js
@@ -4,47 +4,53 @@ Faye.Engine.Redis = Faye.Class(Faye.Engine.Base, {
   DEFAULT_DATABASE: <%= Faye::Engine::Redis::DEFAULT_DATABASE %>,
   DEFAULT_GC:       <%= Faye::Engine::Redis::DEFAULT_GC %>,
   LOCK_TIMEOUT:     <%= Faye::Engine::Redis::LOCK_TIMEOUT %>,
-  
+
   className: 'Engine.Redis',
 
   initialize: function(options) {
     Faye.Engine.Base.prototype.initialize.call(this, options);
-    
-    var redis = require('redis'),
-        host  = this._options.host     || this.DEFAULT_HOST,
-        port  = this._options.port     || this.DEFAULT_PORT,
-        db    = this._options.database || this.DEFAULT_DATABASE,
-        auth  = this._options.password,
-        gc    = this._options.gc       || this.DEFAULT_GC;
-    
+
+    var redis  = require('redis'),
+        host   = this._options.host     || this.DEFAULT_HOST,
+        port   = this._options.port     || this.DEFAULT_PORT,
+        db     = this._options.database || this.DEFAULT_DATABASE,
+        auth   = this._options.password,
+        gc     = this._options.gc       || this.DEFAULT_GC,
+        socket = this._options.socket;
+
     this._ns  = this._options.namespace || '';
-    
-    this._redis = redis.createClient(port, host, {no_ready_check: true});
-    this._subscriber = redis.createClient(port, host, {no_ready_check: true});
-    
+
+    if (socket) {
+      this._redis = redis.createClient(socket, {no_ready_check: true});
+      this._subscriber = redis.createClient(socket, {no_ready_check: true});
+    } else {
+      this._redis = redis.createClient(port, host, {no_ready_check: true});
+      this._subscriber = redis.createClient(port, host, {no_ready_check: true});
+    }
+
     if (auth) {
       this._redis.auth(auth);
       this._subscriber.auth(auth);
     }
     this._redis.select(db);
     this._subscriber.select(db);
-    
+
     var self = this;
     this._subscriber.subscribe(this._ns + '/notifications');
     this._subscriber.on('message', function(topic, message) {
       self.emptyQueue(message);
     });
-    
+
     this._gc = setInterval(function() { self.gc() }, gc * 1000);
   },
-  
+
   disconnect: function() {
     this._redis.end();
     this._subscriber.unsubscribe();
     this._subscriber.end();
     clearInterval(this._gc);
   },
-  
+
   createClient: function(callback, scope) {
     var clientId = Faye.random(), self = this;
     this.debug('Created new client ?', clientId);
@@ -54,16 +60,16 @@ Faye.Engine.Redis = Faye.Class(Faye.Engine.Base, {
       callback.call(scope, clientId);
     });
   },
-  
+
   destroyClient: function(clientId, callback, scope) {
     var self = this;
     this._redis.zrem(this._ns + '/clients', clientId);
     this._redis.del(this._ns + '/clients/' + clientId + '/messages');
-    
+
     this._redis.smembers(this._ns + '/clients/' + clientId + '/channels', function(error, channels) {
       var n = channels.length, i = 0;
       if (n === 0) return callback && callback.call(scope);
-      
+
       Faye.each(channels, function(channel) {
         self.unsubscribe(clientId, channel, function() {
           i += 1;
@@ -75,23 +81,23 @@ Faye.Engine.Redis = Faye.Class(Faye.Engine.Base, {
       });
     });
   },
-  
+
   clientExists: function(clientId, callback, scope) {
     this._redis.zscore(this._ns + '/clients', clientId, function(error, score) {
       callback.call(scope, score !== null);
     });
   },
-  
+
   ping: function(clientId) {
     if (typeof this.timeout !== 'number') return;
-    
+
     var time = new Date().getTime(),
         self = this;
-    
+
     this.debug('Ping ?, ?', clientId, time);
     this._redis.zadd(this._ns + '/clients', time, clientId);
   },
-  
+
   subscribe: function(clientId, channel, callback, scope) {
     var self = this;
     this._redis.sadd(this._ns + '/clients/' + clientId + '/channels', channel);
@@ -100,7 +106,7 @@ Faye.Engine.Redis = Faye.Class(Faye.Engine.Base, {
       if (callback) callback.call(scope);
     });
   },
-  
+
   unsubscribe: function(clientId, channel, callback, scope) {
     var self = this;
     this._redis.srem(this._ns + '/clients/' + clientId + '/channels', channel);
@@ -109,7 +115,7 @@ Faye.Engine.Redis = Faye.Class(Faye.Engine.Base, {
       if (callback) callback.call(scope);
     });
   },
-  
+
   publish: function(message) {
     this.debug('Publishing message ?', message);
 
@@ -117,7 +123,7 @@ Faye.Engine.Redis = Faye.Class(Faye.Engine.Base, {
         jsonMessage = JSON.stringify(message),
         channels    = Faye.Channel.expand(message.channel),
         keys        = Faye.map(channels, function(c) { return self._ns + '/channels' + c });
-    
+
     var notify = function(error, clients) {
       Faye.each(clients, function(clientId) {
         self.debug('Queueing for client ?: ?', clientId, message);
@@ -128,11 +134,11 @@ Faye.Engine.Redis = Faye.Class(Faye.Engine.Base, {
     keys.push(notify);
     this._redis.sunion.apply(this._redis, keys);
   },
-  
+
   emptyQueue: function(clientId) {
     var conn = this.connection(clientId, false);
     if (!conn) return;
-    
+
     var key = this._ns + '/clients/' + clientId + '/messages', self = this;
     this._redis.lrange(key, 0, -1, function(error, jsonMessages) {
       self._redis.ltrim(key, jsonMessages.length, -1);
@@ -141,17 +147,17 @@ Faye.Engine.Redis = Faye.Class(Faye.Engine.Base, {
       });
     });
   },
-  
+
   gc: function() {
     if (typeof this.timeout !== 'number') return;
     this._withLock('gc', function(releaseLock) {
       var cutoff = new Date().getTime() - 1000 * 2 * this.timeout,
           self   = this;
-      
+
       this._redis.zrangebyscore(this._ns + '/clients', 0, cutoff, function(error, clients) {
         var i = 0, n = clients.length;
         if (i === n) return releaseLock();
-        
+
         Faye.each(clients, function(clientId) {
           this.destroyClient(clientId, function() {
             i += 1;
@@ -161,24 +167,24 @@ Faye.Engine.Redis = Faye.Class(Faye.Engine.Base, {
       });
     }, this);
   },
-  
+
   _withLock: function(lockName, callback, scope) {
     var lockKey     = this._ns + '/locks/' + lockName,
         currentTime = new Date().getTime(),
         expiry      = currentTime + this.LOCK_TIMEOUT * 1000 + 1;
         self        = this;
-    
+
     var releaseLock = function() {
       if (new Date().getTime() < expiry) self._redis.del(lockKey);
     };
-    
+
     this._redis.setnx(lockKey, expiry, function(error, set) {
       if (set === 1) return callback.call(scope, releaseLock);
-      
+
       self._redis.get(lockKey, function(error, timeout) {
         var lockTimeout = parseInt(timeout, 10);
         if (currentTime < lockTimeout) return;
-        
+
         self._redis.getset(lockKey, expiry, function(error, oldValue) {
           if (oldValue !== timeout) return;
           callback.call(scope, releaseLock);

--- a/lib/faye/engines/redis.rb
+++ b/lib/faye/engines/redis.rb
@@ -1,47 +1,53 @@
 module Faye
   module Engine
-    
+
     class Redis < Base
       DEFAULT_HOST     = 'localhost'
       DEFAULT_PORT     = 6379
       DEFAULT_DATABASE = 0
       DEFAULT_GC       = 60
       LOCK_TIMEOUT     = 120
-      
+
       def init
         return if @redis
         require 'em-hiredis'
-        
-        host = @options[:host]      || DEFAULT_HOST
-        port = @options[:port]      || DEFAULT_PORT
-        db   = @options[:database]  || 0
-        auth = @options[:password]
-        gc   = @options[:gc]        || DEFAULT_GC
-        @ns  = @options[:namespace] || ''
-        
-        @redis      = EventMachine::Hiredis::Client.connect(host, port)
-        @subscriber = EventMachine::Hiredis::Client.connect(host, port)
-        
+
+        host   = @options[:host]      || DEFAULT_HOST
+        port   = @options[:port]      || DEFAULT_PORT
+        db     = @options[:database]  || 0
+        auth   = @options[:password]
+        gc     = @options[:gc]        || DEFAULT_GC
+        @ns    = @options[:namespace] || ''
+        socket = @options[:socket]
+
+        if socket
+          @redis      = EventMachine::Hiredis::Client.connect(socket, nil)
+          @subscriber = EventMachine::Hiredis::Client.connect(socket, nil)
+        else
+          @redis      = EventMachine::Hiredis::Client.connect(host, port)
+          @subscriber = EventMachine::Hiredis::Client.connect(host, port)
+        end
+
         if auth
           @redis.auth(auth)
           @subscriber.auth(auth)
         end
         @redis.select(db)
         @subscriber.select(db)
-        
+
         @subscriber.subscribe(@ns + '/notifications')
         @subscriber.on(:message) do |topic, message|
           empty_queue(message) if topic == @ns + '/notifications'
         end
-        
+
         @gc = EventMachine.add_periodic_timer(gc, &method(:gc))
       end
-      
+
       def disconnect
         @subscriber.unsubscribe(@ns + '/notifications')
         EventMachine.cancel_timer(@gc)
       end
-      
+
       def create_client(&callback)
         init
         client_id = Faye.random
@@ -55,12 +61,12 @@ module Faye
           end
         end
       end
-      
+
       def destroy_client(client_id, &callback)
         init
         @redis.zrem(@ns + '/clients', client_id)
         @redis.del(@ns + "/clients/#{client_id}/messages")
-        
+
         @redis.smembers(@ns + "/clients/#{client_id}/channels") do |channels|
           n, i = channels.size, 0
           if n == 0
@@ -79,23 +85,23 @@ module Faye
           end
         end
       end
-      
+
       def client_exists(client_id, &callback)
         init
         @redis.zscore(@ns + '/clients', client_id) do |score|
           callback.call(score != nil)
         end
       end
-      
+
       def ping(client_id)
         init
         return unless Numeric === @timeout
-        
+
         time = get_current_time
         debug 'Ping ?, ?', client_id, time
         @redis.zadd(@ns + '/clients', time, client_id)
       end
-      
+
       def subscribe(client_id, channel, &callback)
         init
         @redis.sadd(@ns + "/clients/#{client_id}/channels", channel)
@@ -104,7 +110,7 @@ module Faye
           callback.call if callback
         end
       end
-      
+
       def unsubscribe(client_id, channel, &callback)
         init
         @redis.srem(@ns + "/clients/#{client_id}/channels", channel)
@@ -113,15 +119,15 @@ module Faye
           callback.call if callback
         end
       end
-      
+
       def publish(message)
         init
         debug 'Publishing message ?', message
-        
+
         json_message = JSON.dump(message)
         channels     = Channel.expand(message['channel'])
         keys         = channels.map { |c| @ns + "/channels#{c}" }
-        
+
         @redis.sunion(*keys) do |clients|
           clients.each do |client_id|
             debug 'Queueing for client ?: ?', client_id, message
@@ -130,17 +136,17 @@ module Faye
           end
         end
       end
-      
+
     private
-      
+
       def get_current_time
         (Time.now.to_f * 1000).to_i
       end
-      
+
       def empty_queue(client_id)
         return unless conn = connection(client_id, false)
         init
-        
+
         key = @ns + "/clients/#{client_id}/messages"
         @redis.lrange(key, 0, -1) do |json_messages|
           @redis.ltrim(key, json_messages.size, -1)
@@ -149,7 +155,7 @@ module Faye
           end
         end
       end
-      
+
       def gc
         return unless Numeric === @timeout
         with_lock 'gc' do |release_lock|
@@ -169,16 +175,16 @@ module Faye
           end
         end
       end
-      
+
       def with_lock(lock_name, &block)
         lock_key     = @ns + '/locks/' + lock_name
         current_time = get_current_time
         expiry       = current_time + LOCK_TIMEOUT * 1000 + 1
-        
+
         release_lock = lambda do
           @redis.del(lock_key) if get_current_time < expiry
         end
-        
+
         @redis.setnx(lock_key, expiry) do |set|
           if set == 1
             block.call(release_lock)
@@ -195,8 +201,8 @@ module Faye
         end
       end
     end
-    
+
     register 'redis', Redis
-    
+
   end
 end

--- a/spec/redis.conf
+++ b/spec/redis.conf
@@ -28,6 +28,12 @@ port 6379
 #
 # bind 127.0.0.1
 
+# Specify the path for the unix socket that will be used to listen for
+# incoming connections. There is no default, so Redis will not listen
+# on a unix socket when not specified.
+#
+unixsocket /tmp/redis.sock
+
 # Close the connection after a client is idle for N seconds (0 to disable)
 timeout 300
 


### PR DESCRIPTION
JS example:

```
var bayeux = new Faye.NodeAdapter({
  mount:   '/faye',
  timeout: 45,
  engine:  {
    type: 'redis',
    socket: '/tmp/redis.sock'
  }
});
```
