### PR TITLE
Fix for #96: IE caching JSONP handshakes.

### DIFF
--- a/javascript/transport/jsonp.js
+++ b/javascript/transport/jsonp.js
@@ -25,7 +25,8 @@ Faye.Transport.JSONP = Faye.extend(Faye.Class(Faye.Transport, {
       removeScript();
       self.request(message, 2 * timeout);
     }, 1000 * timeout);
-    
+
+    location.params.nocache = (new Date()).getTime();
     location.params.jsonp = callbackName;
     script.type = 'text/javascript';
     script.src  = location.toURL();


### PR DESCRIPTION
Hi James,

Fix for #96. Add a random parameter to the JSONP URL to bypass IE caching previous responses. 
