### PR TITLE
Export transport to allow apps to disable transports selectively

### DIFF
--- a/javascript/adapters/node_adapter.js
+++ b/javascript/adapters/node_adapter.js
@@ -236,4 +236,5 @@ Faye.extend(Faye.NodeAdapter.prototype, Faye.Logging);
 exports.NodeAdapter = Faye.NodeAdapter;
 exports.Client = Faye.Client;
 exports.Logging = Faye.Logging;
+exports.Transport = Faye.Transport;
 


### PR DESCRIPTION
Export transport to allow node apps to disable transports selectively using the method described here: http://bit.ly/sIyjcW

This is an interim solution until a real transport selection API is available (or desirable).
