### PR TITLE
Detect disconnect as soon as xhr closes.

### DIFF
--- a/javascript/transport/xhr.js
+++ b/javascript/transport/xhr.js
@@ -15,8 +15,15 @@ Faye.Transport.XHR = Faye.extend(Faye.Class(Faye.Transport, {
       if (xhr.readyState !== 4) return;
       var status = xhr.status;
       try {
+        var parsedMessage;
         if ((status >= 200 && status < 300) || status === 304 || status === 1223) {
-          self.receive(JSON.parse(xhr.responseText));
+          try {
+            parsedMessage = JSON.parse(xhr.responseText);
+          } catch (e) {
+          }
+        }
+        if (parsedMessage) {
+          self.receive(parsedMessage);
           self.trigger('up');
         } else {
           retry();
@@ -30,7 +37,7 @@ Faye.Transport.XHR = Faye.extend(Faye.Class(Faye.Transport, {
         xhr = null;
       }
     };
-    
+
     var abort = function() { xhr.abort() };
     Faye.Event.on(Faye.ENV, 'beforeunload', abort);
     


### PR DESCRIPTION
If I ctrl-c the faye server, the xhr request finishes immediately (200 response, empty body), but the xhr transport does not detect this until subsequent attempts fail.

This change causes the transport to go down (and retry) as soon as a response fails to parse.
