### PR TITLE
Add timeout(s) to Faye.Deferrable which behaves the same as EM::Deferrable.

### DIFF
--- a/javascript/mixins/deferrable.js
+++ b/javascript/mixins/deferrable.js
@@ -9,10 +9,10 @@ Faye.Deferrable = {
     this._callbacks.push([callback, scope]);
   },
   
-  timeout: function(seconds) {
+  timeout: function(seconds, message) {
     var _this = this;
     var timer = Faye.ENV.setTimeout(function() {
-      _this.setDeferredStatus('failed', 'Timed out after ' + seconds + ' seconds.');
+      _this.setDeferredStatus('failed', message);
     }, seconds * 1000);
     this._timer = timer;
   },


### PR DESCRIPTION
Hi James.

I've added the timeout(s) method to the deferrable mixin to make it the same as EM::Deferrable (and I needed it).

I hope this meets with your approval.
