### PR TITLE
Make :max_nesting configurabile and be more verbose when exceeded

### DIFF
--- a/lib/faye/adapters/rack_adapter.rb
+++ b/lib/faye/adapters/rack_adapter.rb
@@ -109,7 +109,6 @@ module Faye
       origin   = request.env['HTTP_ORIGIN']
       callback = request.env['async.callback']
       body     = DeferredBody.new
-      
       debug 'Received ?: ?', request.env['REQUEST_METHOD'], json_msg
       @server.flush_connection(message) if request.get?
       
@@ -125,8 +124,12 @@ module Faye
       end
       
       ASYNC_RESPONSE
-    rescue
+    rescue JSON::ParserError => e
+      debug 'Bad request: ?', e
       [400, TYPE_TEXT, ['Bad request']]
+    rescue Exception => e
+      log_error e
+      [500, TYPE_TEXT, ['Internal server error']]
     end
     
     def handle_upgrade(request)


### PR DESCRIPTION
Hello, I was experiencing quiet failures sending complex messages through faye because JSON parses has a limit on the maximum depth.

I thus added a configuration parameter that lets the user configure it while instantiating the parser. I also changed the default exception handler to be more verbose when debugging is activated and differentiate between JSON parsing errors and other exceptions.
