### PR TITLE
separate endpoint for concrete transport

### DIFF
--- a/javascript/protocol/client.js
+++ b/javascript/protocol/client.js
@@ -24,6 +24,7 @@ Faye.Client = Faye.Class({
     this._disabled  = [];
     this.retry      = this._options.retry || this.DEFAULT_RETRY;
     
+    this.transportEndpoints = options.transportEndpoints || {};
     this._selectTransport(Faye.MANDATORY_CONNECTION_TYPES);
     
     this._state     = this.UNCONNECTED;

--- a/javascript/transport/transport.js
+++ b/javascript/transport/transport.js
@@ -71,8 +71,8 @@ Faye.Transport = Faye.extend(Faye.Class({
       var connType = pair[0], klass = pair[1];
       if (Faye.indexOf(connectionTypes, connType) < 0) return resume();
       
-      klass.isUsable(endpoint, function(isUsable) {
-        if (isUsable) callback.call(context, new klass(client, endpoint));
+      klass.isUsable(client.transportEndpoints[connType] || endpoint, function(isUsable) {
+        if (isUsable) callback.call(context, new klass(client, client.transportEndpoints[connType] || endpoint));
         else resume();
       });
     }, function() {


### PR DESCRIPTION
##### Usage

javascript:

```
var client = new Faye.Client('http://'+location.hostname+'/faye', {
  transportEndpoints: {
    websocket: 'http://'+location.hostname+':9292/faye'
  }
});
```

nginx.conf:

```
server {
  listen       80;
  server_name  localhost;

  location /faye {
    proxy_pass http://localhost:9292;
  }
}
```
##### Synopsis

Hello,
I tried to integrate Faye with my web site and stumbled upon an issue for which I didn't find any reliable solution in internet.

Here is the problem:
My site is located at http://mysite.org and faye-endpoint is placed at http://mysite.org:9292/faye
mysite.org and mysite.org:9292 are different domains so Faye can't use AJAX protocol, instead it choses JSONP. But JSONP request causes wait cursor in opera (https://github.com/faye/faye/issues/114) and sometimes i see it in my google chrome.

Okay, lets get rid of different domains and stream all http://mysite.org/faye requests on nginx layer into http://mysite.org:9292/faye

nginx.conf:

```
server {
  listen       80;
  server_name  localhost;

  location /faye {
    proxy_pass http://localhost:9292;
  }
}
```

Yeeeah, it works. Almost. Now we have broken websokets.
It happened because nginx can't proxy_pass websocket connections. Even this module https://github.com/yaoweibin/nginx_tcp_proxy_module can't help(it can stream from a separate domain only(or I just didn't find out how to do opposite))

But why should it be a problem? We don't have to use the same endpoint for websockets, don't we?
So I looked at faye-browser.js and found function

```
  getSocketUrl: function(endpoint) {
    if (Faye.URI) endpoint = Faye.URI.parse(endpoint).toURL();
    return endpoint.replace(/^http(s?):/ig, 'ws$1:');
  },
```

I changed it for

```
getSocketUrl: function(endpoint) {
  if (Faye.URI) endpoint = Faye.URI.parse(endpoint).toURL();
  return endpoint.replace(/^http(s?):/ig, 'ws$1:').replace(':80', ':9292');
},
```

And now websockets works perfectly!

So I refactored this fix into optional hash parameter for Faye.Client constructor options argument.
