### PR TITLE
Make Faye.Engine.Proxy extend EventEmitter and emit events

### DIFF
--- a/javascript/engines/proxy.js
+++ b/javascript/engines/proxy.js
@@ -41,6 +41,7 @@ Faye.Engine.Proxy = Faye.Class({
   connection: function(clientId, create) {
     var conn = this._connections[clientId];
     if (conn || !create) return conn;
+	this.emit('openConnection', clientId);
     return this._connections[clientId] = new Faye.Engine.Connection(this, clientId);
   },
   


### PR DESCRIPTION
When Faye.Engine.Proxy extends EventEmitter it can emit events that a Faye.Engine can hook into. By emitting events for 'connect' and 'closeConnection', this enables an engine to perform additional bookkeeping when a client connects/disconnects.
