### PR TITLE
Trigger events when a connection is opened or closed.

### DIFF
--- a/javascript/engines/proxy.js
+++ b/javascript/engines/proxy.js
@@ -40,11 +40,13 @@ Faye.Engine.Proxy = Faye.Class({
   connection: function(clientId, create) {
     var conn = this._connections[clientId];
     if (conn || !create) return conn;
+    this.trigger('openConnection', clientId);
     return this._connections[clientId] = new Faye.Engine.Connection(this, clientId);
   },
   
   closeConnection: function(clientId) {
     this.debug('Closing connection for ?', clientId);
+	this.trigger('closeConnection', clientId);
     delete this._connections[clientId];
   },
   

--- a/lib/faye/engines/proxy.rb
+++ b/lib/faye/engines/proxy.rb
@@ -63,11 +63,13 @@ module Faye
       def connection(client_id, create)
         conn = @connections[client_id]
         return conn if conn or not create
+        trigger(:openConnection, client_id)
         @connections[client_id] = Connection.new(self, client_id)
       end
       
       def close_connection(client_id)
         debug 'Closing connection for ?', client_id
+        trigger(:closeConnection, client_id)
         @connections.delete(client_id)
       end
       


### PR DESCRIPTION
Trigger 'openConnection' and 'closeConnection' events with the clientId when a connection is opened or closed. This allows the engine to do some additional bookkeeping if it needs to concerning which clients are currently connected.
