### PR TITLE
Update javascript/transport/node_http.js

### DIFF
--- a/javascript/transport/node_http.js
+++ b/javascript/transport/node_http.js
@@ -8,7 +8,7 @@ Faye.Transport.NodeHttp = Faye.extend(Faye.Class(Faye.Transport, {
         self     = this;
     
     var cookies = this.cookies.getCookies({domain: uri.hostname, path: uri.pathname}),
-        params  = this._buildParams(uri, content, cookies, secure)
+        params  = this._buildParams(uri, content, cookies, secure);
         //small hack to pass certs from faye.client call down tls.connect further down the chain
         Faye.extend(params,this._client._options);
         var request = client.request(params);


### PR DESCRIPTION
Merges the options passed to faye.client to ensure the  certificate info gets 
passed to tls.connect.

In order for this to work requires one of two creations of the options object with the client.
Note: options.agent creation is mandatory for some reason
        1)
        var options = {
          passphrase: 'password'
          ,pfx: fs.readFileSync("ssl/agent1.pfx")
          ,timeout: 120
        };
        options.agent = new https.Agent(options);
        var client = new faye.Client('https://localhost:4443/faye', options);

        2)
        var options = {
           passphrase: 'password'
           ,key: fs.readFileSync("ssl/agent1-key.pem")
           ,cert: fs.readFileSync("ssl/agent1-cert.pem")
           ,timeout: 120
        };
        options.agent = new https.Agent(options);
        var client = new faye.Client('https://localhost:4443/faye', options);

Server would look something like this:

var https = require('https')
    , faye = require('faye')
    , fs = require('fs');

//faye.Logging.logLevel = 'debug';
var bayeux = new faye.NodeAdapter({mount: '/faye', timeout: 45});

var options = {
    passphrase: 'password',
    key: fs.readFileSync('ssl/server-key.pem'),
    cert: fs.readFileSync('ssl/server-cert.pem'),
    ca:     [fs.readFileSync('ssl/ca1-cert.pem')],
    requestCert:        true,
    rejectUnauthorized: true
};
options.agent = new https.Agent(options);

var server = https.createServer(options, ServerAuthHandler);
console.log('server created');
bayeux.attach(server);
console.log('bayeux listener attached');
server.listen(4443);
console.log('server listening on 4443');
