### PR TITLE
remove content-type and content-length from 304

### DIFF
--- a/lib/faye/adapters/static_server.rb
+++ b/lib/faye/adapters/static_server.rb
@@ -43,8 +43,12 @@ module Faye
       headers['Last-Modified'] = cache[:mtime].httpdate
       
       if env['HTTP_IF_NONE_MATCH'] == cache[:digest]
+        headers.delete('Content-Type')
+        headers.delete('Content-Length')
         [304, headers, ['']]
       elsif ims and cache[:mtime] <= Time.httpdate(ims)
+        headers.delete('Content-Type')
+        headers.delete('Content-Length')
         [304, headers, ['']]
       else
         headers['Content-Length'] = cache[:content].bytesize.to_s unless no_content_length


### PR DESCRIPTION
Content-Type and Content-Length are not allowed in 304, caused Rack::Lint::LintError when request faye/client.js
