### PR TITLE
Use multi_json instead of yajl-ruby to support a multitude of json parsers

### DIFF
--- a/faye.gemspec
+++ b/faye.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency "eventmachine", ">= 0.12.0"
   s.add_dependency "faye-websocket", ">= 0.4.0"
   s.add_dependency "rack", ">= 1.0.0"
-  s.add_dependency "yajl-ruby", ">= 1.0.0"
+  s.add_dependency "multi_json"
 
   s.add_development_dependency "compass", "~> 0.10.0"
   s.add_development_dependency "jake", ">= 1.1.1"

--- a/lib/faye.rb
+++ b/lib/faye.rb
@@ -10,7 +10,7 @@ require 'rack'
 require 'set'
 require 'time'
 require 'uri'
-require 'yajl'
+require 'multi_json'
 
 module Faye
   VERSION = '0.8.6'
@@ -80,7 +80,7 @@ module Faye
   
   def self.to_json(value)
     case value
-      when Hash, Array then Yajl::Encoder.encode(value)
+      when Hash, Array then MultiJson.dump(value)
       when String, NilClass then value.inspect
       else value.to_s
     end

--- a/lib/faye/adapters/rack_adapter.rb
+++ b/lib/faye/adapters/rack_adapter.rb
@@ -101,7 +101,7 @@ module Faye
       
       debug "Received message via HTTP #{request.request_method}: ?", json_msg
       
-      message  = Yajl::Parser.parse(json_msg)
+      message  = MultiJson.load(json_msg)
       jsonp    = request.params['jsonp'] || JSONP_CALLBACK
       headers  = request.get? ? TYPE_SCRIPT.dup : TYPE_JSON.dup
       origin   = request.env['HTTP_ORIGIN']
@@ -135,7 +135,7 @@ module Faye
         begin
           debug "Received message via WebSocket[#{ws.version}]: ?", event.data
           
-          message   = Yajl::Parser.parse(event.data)
+          message   = MultiJson.load(event.data)
           client_id = Faye.client_id_from_messages(message)
           
           @server.open_socket(client_id, ws)

--- a/lib/faye/transport/http.rb
+++ b/lib/faye/transport/http.rb
@@ -54,7 +54,7 @@ module Faye
     end
     
     def handle_response(response, retry_block)
-      message = Yajl::Parser.parse(response) rescue nil
+      message = MultiJson.load(response) rescue nil
       if message
         receive(message)
         trigger(:up)

--- a/lib/faye/transport/web_socket.rb
+++ b/lib/faye/transport/web_socket.rb
@@ -58,7 +58,7 @@ module Faye
       end
       
       @socket.onmessage = lambda do |event|
-        messages = [Yajl::Parser.parse(event.data)].flatten
+        messages = [MultiJson.load(event.data)].flatten
         messages.each { |message| @messages.delete(message['id']) }
         receive(messages)
       end

--- a/spec/ruby/rack_adapter_spec.rb
+++ b/spec/ruby/rack_adapter_spec.rb
@@ -14,7 +14,7 @@ describe Faye::RackAdapter do
   let(:content_length)        { last_response["Content-Length"] }
   let(:cache_control)         { last_response["Cache-Control"] }
   let(:access_control_origin) { last_response["Access-Control-Allow-Origin"] }
-  let(:json)                  { Yajl::Parser.parse(body) }
+  let(:json)                  { MultiJson.load(body) }
   let(:body)                  { last_response.body }
   let(:status)                { last_response.status.to_i }
   


### PR DESCRIPTION
The hope is that this will allow Faye to run on Jruby servers as well.  

I only did _do no harm_ verification of tests, a single spec failed when I forked and is still failing in  rack_adapter_spec.rb
