### PR TITLE
The interval was not passed to the engine, so the option was not working.

### DIFF
--- a/lib/faye/protocol/server.rb
+++ b/lib/faye/protocol/server.rb
@@ -14,6 +14,7 @@ module Faye
       @options    = options || {}
       engine_opts = @options[:engine] || {}
       engine_opts[:timeout] = @options[:timeout]
+      engine_opts[:interval] = @options[:interval]
       @engine     = Faye::Engine.get(engine_opts)
 
       info 'Created new server: ?', @options


### PR DESCRIPTION
The interval was not passed to the engine, so the option was not working.

``` ruby
  Faye::Server.new({:interval=>9}).engine.interval # => 0
```

Now 

``` ruby
  Faye::Server.new({:interval=>9}).engine.interval # => 9
```
