### PR TITLE
Allow passing options to Rack handler in listen

### DIFF
--- a/lib/faye/adapters/rack_adapter.rb
+++ b/lib/faye/adapters/rack_adapter.rb
@@ -48,10 +48,10 @@ module Faye
       @client ||= Client.new(@server)
     end
 
-    def listen(port, ssl_options = nil)
+    def listen(port, ssl_options = nil, handler_options = {})
       Faye::WebSocket.load_adapter('thin')
       handler = Rack::Handler.get('thin')
-      handler.run(self, :Port => port) do |s|
+      handler.run(self, handler_options.merge(:Port => port)) do |s|
         if ssl_options
           s.ssl = true
           s.ssl_options = {


### PR DESCRIPTION
I had the need to pass specific options to thin (namely :signals => false to disable its signal handlers) but faye's listen method didn't give me the possibility.

This patch adds such support.
