### PR TITLE
Loading faye-browser.js fails because 'this' is undefined when checking this.JSON

### DIFF
--- a/javascript/util/browser/json.js
+++ b/javascript/util/browser/json.js
@@ -158,7 +158,7 @@
 // Create a JSON object only if one does not already exist. We create the
 // methods in a closure to avoid creating global variables.
 
-if (!this.JSON) {
+if (!this || !this.JSON) {
     JSON = {};
 }
 (function () {


### PR DESCRIPTION
When including faye-browser.js in my client builds the browser throws an error (due to 'use strict') at faye-browser.js:1448 because 'this' is undefined.

This PR fixes the issue by defining the JSON object when either 'this' or 'this.JSON' is undefined.
