### PR TITLE
Allow limiting the size of the batched messages

### DIFF
--- a/lib/faye/protocol/client.rb
+++ b/lib/faye/protocol/client.rb
@@ -53,6 +53,10 @@ module Faye
       @headers[name.to_s] = value.to_s
     end
 
+    def batch_limit=(limit)
+      @batch_limit = limit
+    end
+
     def state
       case @state
       when UNCONNECTED  then :UNCONNECTED
@@ -312,6 +316,7 @@ module Faye
         @transport = transport
         @transport.cookies = @cookies
         @transport.headers = @headers
+        @transport.batch_limit = @batch_limit unless @batch_limit.nil?
 
         transport.bind :down do
           if @transport_up.nil? or @transport_up

--- a/lib/faye/transport/http.rb
+++ b/lib/faye/transport/http.rb
@@ -69,6 +69,11 @@ module Faye
         @cookies.set_cookie(@endpoint, cookie)
       end
     end
+
+    def batching_limit_exceeded?(message)
+      return false if @batch_limit.nil?
+      Faye.to_json(message).bytesize >= @batch_limit
+    end
   end
 
   Transport.register 'long-polling', Transport::Http


### PR DESCRIPTION
If enough large messages are sent in a short period of time, the request body
could be larger than the server accepts. This patch allows limiting the size
of the batched messages. If a message is added which would cause the batched
messages to exceed the allowed size, the batched messages are flushed before
the new message is added to the outbox.

It is left as an application concern to limit any individual message from
being too large.

If this patch is something that you are interested in, then I can write tests for it. And also, consider mitigating any possible performance impact this may have.
