### PR TITLE
Refactored the matcher for Node to allow mounting Faye at the root path

### DIFF
--- a/javascript/adapters/node_adapter.js
+++ b/javascript/adapters/node_adapter.js
@@ -37,7 +37,31 @@ Faye.NodeAdapter = Faye.Class({
   initialize: function(options) {
     this._options    = options || {};
     this._endpoint   = this._options.mount || this.DEFAULT_ENDPOINT;
-    this._endpointRe = new RegExp('^' + this._endpoint.replace(/\/$/, '') + '(/[^/]+)*(\\.[^\\.]+)?$');
+    var sanitizedEndpoint = '/' + this._endpoint.replace(/^\/+|\/+$/g, ''); // A slash, followed by the specified endpoint with leading and trailing slashes removed
+    this._endpointRe = new RegExp(
+      // Starts and ends with
+      '^' + 
+      
+      (
+        // The endpoint followed by anything at all (including nothing), if the endpoint is "/"
+        sanitizedEndpoint === '/' ? '/.*' :
+
+        // Otherwise, one of…
+        '(' +
+
+          // Exactly the endpoint
+          sanitizedEndpoint +
+
+          '|' + // OR
+
+          // The endpoint, followed by a slash, followed by at least one non-slash character
+          sanitizedEndpoint + '/[^/]+' +
+
+        ')'
+      ) +
+      
+      '$'
+    );
     this._server     = new Faye.Server(this._options);
 
     this._static = new Faye.StaticServer(path.dirname(__filename) + '/../browser', /\.(?:js|map)$/);


### PR DESCRIPTION
As brought up by a Rubyist in #216, the new endpoint matcher prevents you from mounting Faye at the root path ("/"). Moreover, its extension matching rule `(\\.[^\\.]+)?` was never matching anything because the regular expression that came just before it would short-circuit it every time.

Given a mountpoint of "/", this new matcher will match:

```
/
/faye-browser.js
/foo
/foo/
/foo/bar
/foo/bar/
```

Given a mountpoint of "/bayeux", this new matcher will match:

```
/bayeux
/bayeux/faye-browser.js
/bayeux/foo
/bayeux/foo/
/bayeux/foo/bar
/bayeux/foo/bar/
```

…but will **not** match:

```
/bayeux/
```

This behavior should be consistent with @jcoglan's comment here: https://github.com/faye/faye/issues/170#issuecomment-10144269
