### PR TITLE
Lock concat-stream to version 1.2.x to ensure compatibility with node v0.8.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 , "main"            : "./node/faye-node"
 , "browserify"      : "./browser/faye-browser"
 
-, "dependencies"    : { "concat-stream": ""
+, "dependencies"    : { "concat-stream": "1.2.x"
                       , "cookiejar": ""
                       , "csprng": ""
                       , "faye-websocket": ">=0.7.0"


### PR DESCRIPTION
solves https://github.com/faye/faye/issues/267
