### PR TITLE
Faye.copyObject doesn't work with instance of Date

### DIFF
--- a/javascript/faye.js
+++ b/javascript/faye.js
@@ -40,6 +40,8 @@ var Faye = {
       i = object.length;
       while (i--) clone[i] = Faye.copyObject(object[i]);
       return clone;
+    } else if (object instanceof Date) {
+        return new Date(object);
     } else if (typeof object === 'object') {
       clone = (object === null) ? null : {};
       for (key in object) clone[key] = Faye.copyObject(object[key]);


### PR DESCRIPTION
After this fix, you can publish to channel with `Date` in `message.data` with memory engine
NOTE: Redis engine doesn't call `Faye.copyObject` so It dodges a bullet here
