### PR TITLE
Modified http.rb to set a proxy from the http_proxy environment variable...

### DIFF
--- a/lib/faye/transport/http.rb
+++ b/lib/faye/transport/http.rb
@@ -48,8 +48,8 @@ module Faye
                   options = {                 # for em-http-request >= 1.0
                     :inactivity_timeout => 0  # connection inactivity (post-setup) timeout (0 = disable timeout)
                   }
-                  if ENV['http_proxy']
-                    proxy = URI(ENV['http_proxy'])
+                  proxy = @endpoint.find_proxy
+                  if proxy
                     options.merge!({
                       :proxy => { :host => proxy.host, :port => proxy.port, :type => :http }
                     })


### PR DESCRIPTION
Modified http.rb to detect whether the http_proxy environment variable has been set and use it if available. This mirrors the behaviour of other ruby http libraries.
