### PR TITLE
Add method to check for already subscribed channel

### DIFF
--- a/lib/faye/protocol/client.rb
+++ b/lib/faye/protocol/client.rb
@@ -62,6 +62,13 @@ module Faye
     end
 
     # Request
+    # MUST include: * channel string name
+    # Easly check if a client has already subscribed to a channel
+    def has_subscription?(name)
+      @channels.has_subscription?(name)
+    end
+
+    # Request
     # MUST include:  * channel
     #                * version
     #                * supportedConnectionTypes


### PR DESCRIPTION
Hello,

I was kinda frustrated to see that there was no method or way to see if my client already subscribed to a channel (the @channels variable has no getter for some reason). For this reason I've added a method to see if a channel is already subscribed. 
