### PR TITLE
Ensure container backgrounds expand to full width on scroll

### DIFF
--- a/site/src/stylesheets/screen.sass
+++ b/site/src/stylesheets/screen.sass
@@ -9,6 +9,8 @@ body
 .container
   width:              960px
   margin:             0 auto
+  min-width:          100%
+  display:            inline-block
   text-align:         left
   position:           relative
 
@@ -28,6 +30,8 @@ body
 
 .header
   border-bottom:      4px solid #ccc
+  min-width:          100%
+  display:            inline-block
 
   h1
     margin:           0 0 0 0
@@ -81,6 +85,8 @@ body
 .footer
   border-top:         4px solid #ccc
   padding-bottom:     2em
+  min-width:          100%
+  display:            inline-block
   p
     font-size:        80%
     margin:           1em 0 1em 320px


### PR DESCRIPTION
This fixes the issue raised in #297

I couldn't figure out how to run the static site locally, but making the same edits in dev tools shows the fix on firefox/safari/chrome.

![sub messaging for the web 2014-05-12 21-29-38 2014-05-12 21-30-21](https://cloud.githubusercontent.com/assets/78225/2949917/3e4f9892-da14-11e3-93cb-e2ab1031fc3b.png)
