### PR TITLE
JSHint Fixes

### DIFF
--- a/javascript/.jshintrc
+++ b/javascript/.jshintrc
@@ -1,0 +1,7 @@
+{
+  "lastsemic": true,
+  "boss": true,
+  "unused": true,
+  "loopfunc": true,
+  "-W014": true
+}

--- a/javascript/adapters/node_adapter.js
+++ b/javascript/adapters/node_adapter.js
@@ -87,7 +87,6 @@ Faye.NodeAdapter = Faye.Class({
   handle: function(request, response) {
     var requestUrl    = url.parse(request.url, true),
         requestMethod = request.method,
-        origin        = request.headers.origin,
         self          = this;
 
     request.originalUrl = request.url;

--- a/javascript/engines/proxy.js
+++ b/javascript/engines/proxy.js
@@ -106,7 +106,7 @@ Faye.Engine.METHODS.forEach(function(method) {
   Faye.Engine.Proxy.prototype[method] = function() {
     return this._engine[method].apply(this._engine, arguments);
   };
-})
+});
 
 Faye.extend(Faye.Engine.Proxy.prototype, Faye.Publisher);
 Faye.extend(Faye.Engine.Proxy.prototype, Faye.Logging);

--- a/javascript/mixins/deferrable.js
+++ b/javascript/mixins/deferrable.js
@@ -32,7 +32,7 @@ Faye.Deferrable = {
   setDeferredStatus: function(status, value) {
     if (this._timer) Faye.ENV.clearTimeout(this._timer);
 
-    var promise = this.then();
+    this.then();
 
     if (status === 'succeeded')
       this._fulfill(value);

--- a/javascript/mixins/logging.js
+++ b/javascript/mixins/logging.js
@@ -7,10 +7,10 @@ Faye.Logging = {
     debug:  0
   },
 
-  writeLog: function(messageArgs, level) {
+  writeLog: function(_messageArgs, level) {
     if (!Faye.logger) return;
 
-    var messageArgs = Array.prototype.slice.apply(messageArgs),
+    var messageArgs = Array.prototype.slice.apply(_messageArgs),
         banner      = '[Faye',
         klass       = this.className,
 
@@ -39,7 +39,7 @@ Faye.Logging = {
 
 (function() {
   for (var key in Faye.Logging.LOG_LEVELS)
-    (function(level, value) {
+    (function(level) {
       Faye.Logging[level] = function() {
         this.writeLog(arguments, level);
       };

--- a/javascript/protocol/client.js
+++ b/javascript/protocol/client.js
@@ -293,7 +293,7 @@ Faye.Client = Faye.Class({
   },
 
   receiveMessage: function(message) {
-    var id = message.id, timeout, callback;
+    var id = message.id, callback;
 
     if (message.successful !== undefined) {
       callback = this._responseCallbacks[id];
@@ -317,7 +317,7 @@ Faye.Client = Faye.Class({
   messageError: function(messages, immediate) {
     var retry = this._retry,
         self  = this,
-        id, message, timeout;
+        id, message;
 
     for (var i = 0, n = messages.length; i < n; i++) {
       message = messages[i];

--- a/javascript/protocol/server.js
+++ b/javascript/protocol/server.js
@@ -105,7 +105,6 @@ Faye.Server = Faye.Class({
 
   _handleMeta: function(message, local, callback, context) {
     var method   = Faye.Channel.parse(message.channel)[1],
-        clientId = message.clientId,
         response;
 
     if (Faye.indexOf(this.META_METHODS, method) < 0) {

--- a/javascript/transport/transport.js
+++ b/javascript/transport/transport.js
@@ -63,7 +63,7 @@ Faye.Transport = Faye.extend(Faye.Class({
     this.debug('Client ? received from ?: ?',
                this._client._clientId, Faye.URI.stringify(this.endpoint), responses);
 
-    for (var i = 0, n = responses.length; i < n; i++)
+    for (var i = 0, m = responses.length; i < m; i++)
       this._client.receiveMessage(responses[i]);
   },
 

--- a/spec/.jshintrc
+++ b/spec/.jshintrc
@@ -1,0 +1,7 @@
+{
+  "asi": true,
+  "unused": true,
+  "loopfunc": true,
+  "-W085": true,
+  "-W014": true
+}

--- a/spec/javascript/client_spec.js
+++ b/spec/javascript/client_spec.js
@@ -470,7 +470,6 @@ JS.ENV.ClientSpec = JS.Test.describe("Client", function() { with(this) {
         }})
 
         it("reports the error through an errback", function(resume) { with(this) {
-          var error = null
           client.subscribe("/meta/foo").errback(function(error) {
             resume(function() {
               assertEqual( objectIncluding({code: 403, params: ["/meta/foo"], message: "Forbidden channel"}), error )

--- a/spec/javascript/engine_spec.js
+++ b/spec/javascript/engine_spec.js
@@ -87,8 +87,7 @@ JS.ENV.EngineSteps = JS.Test.asyncSteps({
   },
 
   expect_no_event: function(name, event, args, resume) {
-    var params  = [this._clients[name]].concat(args),
-        handler = function() {}
+    var handler = function() {}
 
     this.engine.bind(event, handler)
     this.expect(handler, "apply").exactly(0)

--- a/spec/javascript/node_adapter_spec.js
+++ b/spec/javascript/node_adapter_spec.js
@@ -43,9 +43,9 @@ JS.ENV.NodeAdapterSteps = JS.Test.asyncSteps({
     request.end()
   },
 
-  post: function(path, body, resume) {
-    var self    = this,
-        body    = (typeof body === "string") ? body : querystring.stringify(body),
+  post: function(path, _body, resume) {
+    var self    = this;
+        body    = (typeof _body === "string") ? _body : querystring.stringify(_body),
 
         headers = Faye.extend({
           "Host":           "localhost",

--- a/spec/node.js
+++ b/spec/node.js
@@ -13,7 +13,7 @@ FakeSocket.prototype.write = function(buffer, encoding) {
 }
 FakeSocket.prototype.read = function() {
   var output = []
-  this._fragments.forEach(function(buffer, i) {
+  this._fragments.forEach(function(buffer) {
     for (var j = 0, n = buffer[0].length; j < n; j++)
     output.push(buffer[0][j])
   })


### PR DESCRIPTION
This is a pretty straight-forward: it simply adds .jshintrc configurations for `/javascript/`  and `/spec/` so that those of us using editors with jshint build in don't get loads of warnings about semi-colons etc.  

In addition, I've gone through the warnings and removed some duplicate `var` definitions, unused variables, and other really minor problems. 

Even if you choose not to include the .jshintrc configs, dropping the unused variables and duplicate vars may still be a good idea.
