### PR TITLE
Reset the Faye connection

### DIFF
--- a/javascript/protocol/client.js
+++ b/javascript/protocol/client.js
@@ -292,6 +292,12 @@ Faye.Client = Faye.Class({
     return publication;
   },
 
+  reset: function() {
+    this._clientId  = null;
+    this._state     = this.UNCONNECTED;
+    this._cycleConnection();
+  },
+
   receiveMessage: function(message) {
     var id = message.id, timeout, callback;
 

--- a/javascript/protocol/client.js
+++ b/javascript/protocol/client.js
@@ -293,7 +293,6 @@ Faye.Client = Faye.Class({
   },
 
   reset: function() {
-    this._clientId  = null;
     this._state     = this.UNCONNECTED;
     this._cycleConnection();
   },

--- a/spec/javascript/client_spec.js
+++ b/spec/javascript/client_spec.js
@@ -710,6 +710,19 @@ JS.ENV.ClientSpec = JS.Test.describe("Client", function() { with(this) {
     }})
   }})
 
+  describe("reset", function() { with(this) {
+    before(function() { with(this) {
+      createConnectedClient()
+    }})
+
+    it("should disconnect the client", function() { with(this) {
+      client.reset();
+      assertEqual( client.UNCONNECTED, client._state )
+      assertEqual( null, client._clientId )
+    }})
+
+  }})
+
   describe("network notifications", function() { with(this) {
     before(function() { with(this) {
       createClient()

--- a/spec/javascript/client_spec.js
+++ b/spec/javascript/client_spec.js
@@ -718,7 +718,6 @@ JS.ENV.ClientSpec = JS.Test.describe("Client", function() { with(this) {
     it("should disconnect the client", function() { with(this) {
       client.reset();
       assertEqual( client.UNCONNECTED, client._state )
-      assertEqual( null, client._clientId )
     }})
 
   }})


### PR DESCRIPTION
Sometimes the client just knows that the Faye connection is no longer valid. For example, on Gitter we detect when the client computer has just awoken from sleep. If the client computer has been sleeping for several minutes or more, the best thing to do is to renegotiate the connection from the handshake onwards. This saves network round trips and allows the client to reconnect much faster than if it assumes that it's `socketId` is still valid. This PR allows the client to instruct the Faye client to do just that.

Any existing subscriptions will be maintained through to the new connection.

ps: I'm definitely not sold on the name `reset` for the method, if you've got a better suggestion, I would definitely be up for it.