### PR TITLE
Option to not reuse transport on handshake

### DIFF
--- a/javascript/protocol/client.js
+++ b/javascript/protocol/client.js
@@ -83,6 +83,11 @@ Faye.Client = Faye.Class({
     if (this._advice.reconnect === this.NONE) return;
     if (this._state !== this.UNCONNECTED) return;
 
+    if (this._options.reuseTransport === false && this._transport) {
+      this._transport.close();
+      this._transport = null;
+    }
+
     this._state = this.CONNECTING;
     var self = this;
 


### PR DESCRIPTION
Last PR for the night, I promise :smile: 

For websockets in particular we have discovered a huge range of browser and server bugs which can lead to dodgy connections. For example, I recently reported a fairly serious bug in ELB to Amazon which caused Blink based browsers to report a websocket connection as being good but all traffic sent and received was ignored. To Amazon's credit, after my report, they quickly rolled out a fix for this particular bug, but there are others.

In this sort of situation, the Faye connection may eventually time out and rehandshake over the same dodgy websocket, leading to further problems. It would be much better if we could just trash the connection and create a new one.

This pull-request gives us the option of NOT reusing the same transport when a Faye client renegotiates the handshake. If the Faye client has already selected a transport (ie, it had a previous connection to the server) the option `{ reuseTransport: false }` will close the transport and select a new transport in the same manner as when the Faye client is initially instantiated.
