### PR TITLE
Move the place the clientId is stripped from outgoing message so monitoring callbacks can access it (related to #302)

### DIFF
--- a/javascript/engines/connection.js
+++ b/javascript/engines/connection.js
@@ -7,6 +7,7 @@ Faye.Engine.Connection = Faye.Class({
   },
 
   deliver: function(message) {
+    delete message.clientId;
     if (this.socket) return this.socket.send(message);
     this._inbox.push(message);
     this._beginDeliveryTimeout();

--- a/javascript/protocol/server.js
+++ b/javascript/protocol/server.js
@@ -94,7 +94,6 @@ Faye.Server = Faye.Class({
     if (!Faye.Grammar.CHANNEL_NAME.test(channelName))
       error = Faye.Error.channelInvalid(channelName);
 
-    delete message.clientId;
     if (!error) this._engine.publish(message);
 
     response = this._makeResponse(message);

--- a/lib/faye/engines/connection.rb
+++ b/lib/faye/engines/connection.rb
@@ -15,6 +15,7 @@ module Faye
       end
 
       def deliver(message)
+        message.delete('clientId')
         return @socket.send(message) if @socket
         return unless @inbox.add?(message)
         begin_delivery_timeout

--- a/lib/faye/protocol/server.rb
+++ b/lib/faye/protocol/server.rb
@@ -94,7 +94,6 @@ module Faye
         error = Faye::Error.channel_invalid(channel_name)
       end
 
-      message.delete('clientId')
       @engine.publish(message) unless error
 
       response = make_response(message)


### PR DESCRIPTION
I've had a look and indeed the `Connection#deliver` method is only called for non meta publish, so there you go.
