### PR TITLE
Fix link to Bayeux protocol

### DIFF
--- a/site/src/pages/index.haml
+++ b/site/src/pages/index.haml
@@ -4,7 +4,7 @@
       h3. What is it?
 
       Faye is a publish-subscribe messaging system based on the
-      "Bayeux":http://svn.cometd.com/trunk/bayeux/bayeux.html protocol. It
+      "Bayeux":http://svn.cometd.org/trunk/bayeux/bayeux.html protocol. It
       provides message servers for "Node.js":http://nodejs.org and
       "Ruby":http://www.ruby-lang.org, and clients for use on the server and in
       all major web browsers.


### PR DESCRIPTION
Looks like the protocol spec is only available at `.org` (also: there SSL cert there is self-signed, too bad…)
