### PR TITLE
Add callback to client's disconnect method

### DIFF
--- a/javascript/protocol/client.js
+++ b/javascript/protocol/client.js
@@ -148,7 +148,7 @@ Faye.Client = Faye.Class({
   //                * id                  MAY include:   * error
   //                                                     * ext
   //                                                     * id
-  disconnect: function() {
+  disconnect: function(callback) {
     if (this._state !== this.CONNECTED) return;
     this._state = this.DISCONNECTED;
 
@@ -160,6 +160,7 @@ Faye.Client = Faye.Class({
 
     }, {}, function(response) {
       if (response.successful) this._dispatcher.close();
+      if (callback) callback(response.successful);
     }, this);
 
     this.info('Clearing channel listeners for ?', this._dispatcher.clientId);


### PR DESCRIPTION
In my node to node client i currently have something like this:

```
process.on('SIGINT', function() {
  console.log('Got SIGINT signal, let me just disconnect...');
  client.disconnect();
  setTimeout(function() {
    process.exit(0);
  }, 1000);

});
```

I believe this approach is somewhat cleaner:

```
process.on('SIGINT', function() {
  console.log('Got SIGINT signal, let me just disconnect...');
  client.disconnect(function() {
    process.exit(0);
  });
});
```

However - i dont know if this will break the api ? - the client.disconnect() should work just as before if no callback is provided
