### PR TITLE
simplify copyObject()

### DIFF
--- a/javascript/faye.js
+++ b/javascript/faye.js
@@ -37,19 +37,7 @@ var Faye = {
   },
 
   copyObject: function(object) {
-    var clone, i, key;
-    if (object instanceof Array) {
-      clone = [];
-      i = object.length;
-      while (i--) clone[i] = Faye.copyObject(object[i]);
-      return clone;
-    } else if (typeof object === 'object') {
-      clone = (object === null) ? null : {};
-      for (key in object) clone[key] = Faye.copyObject(object[key]);
-      return clone;
-    } else {
-      return object;
-    }
+  	return JSON.parse(JSON.stringify(object));
   },
 
   commonElement: function(lista, listb) {


### PR DESCRIPTION
Today I ran into a problem with faye, getting the wonderful `Uncaught RangeError: Maximum call stack size exceeded` :boom:. Until I reluctantly looked at the source-code, I was unable to understand what caused the error.

Anyway, what caused the problem was that the published message included objects with circular references. This made your existing, recursive, `copyObject` function go on forever.

In this humble PR, `copyObject` is simplified, while adding "support" for circular references... it might [speed things up](http://stackoverflow.com/a/5344074/93222) a little, as well.