### PR TITLE
Fix: client not disconnected properly when websocket is closed abruptly

### DIFF
--- a/javascript/adapters/node_adapter.js
+++ b/javascript/adapters/node_adapter.js
@@ -184,7 +184,7 @@ Faye.NodeAdapter = Faye.Class({
 
         if (clientId && cid && cid !== clientId) self._server.closeSocket(clientId, false);
         self._server.openSocket(cid, ws, request);
-        clientId = cid;
+        if (cid) clientId = cid;
 
         self._server.process(message, request, function(replies) {
           if (ws) ws.send(Faye.toJSON(replies));

--- a/lib/faye/adapters/rack_adapter.rb
+++ b/lib/faye/adapters/rack_adapter.rb
@@ -186,7 +186,7 @@ module Faye
 
           @server.close_socket(client_id, false) if client_id and cid and cid != client_id
           @server.open_socket(cid, ws, request)
-          client_id = cid
+          client_id = cid if cid
 
           @server.process(message, request) do |replies|
             ws.send(Faye.to_json(replies)) if ws


### PR DESCRIPTION
When a websocket is closed, the rack adapter tries to notify the server it's related clientId has left.

However, the ``client_id`` / ``clientId`` variable is nil since ``Faye.client_id_from_messages(message)`` /  ``Faye.clientIdFromMessages(message);`` returns a clientId only when the message is a ``/meta/connect``

Therefore, when a websocket is closed abruptly, faye will not acknowledge its leaving until the gc is performed.

This patch only overrides client_id when cid is not nil, fixing this issue.