### PR TITLE
Ensured that JSONP replies are defined prior to calling _receive()

### DIFF
--- a/javascript/transport/jsonp.js
+++ b/javascript/transport/jsonp.js
@@ -25,7 +25,8 @@ Faye.Transport.JSONP = Faye.extend(Faye.Class(Faye.Transport, {
 
     Faye.ENV[callbackName] = function(replies) {
       cleanup();
-      self._receive(replies);
+      if (replies)
+        self._receive(replies);
     };
 
     script.type = 'text/javascript';


### PR DESCRIPTION
When we deployed the faye-browser.js JavaScript in conjunction with Pushpin's (https://github.com/fanout/pushpin) new Faye / Bayeux  features, a user reported an error in his client related to an empty body coming across. After investigating we were able to resolve the issue in Pushpin, but also realized that faye-browser.js shouldn't pass empty JSONP replies to the receive() method as that was the cause on the client-side. This fix simply ensures that replies is defined prior to passing it to the receive() method.