### PR TITLE
CORS for custom headers

### DIFF
--- a/javascript/adapters/node_adapter.js
+++ b/javascript/adapters/node_adapter.js
@@ -239,9 +239,6 @@ Faye.NodeAdapter = Faye.Class({
       'Access-Control-Allow-Methods':     'POST, GET, PUT, DELETE, OPTIONS',
       'Access-Control-Allow-Origin':      '*',
     };
-    if(request.headers.origin) {
-        headers['Access-Control-Allow-Origin'] =  request.headers.origin;
-    }
     if(request.headers['access-control-request-method']) {
         headers['Access-Control-Allow-Methods'] = request.headers['access-control-request-method'];
     }

--- a/javascript/adapters/node_adapter.js
+++ b/javascript/adapters/node_adapter.js
@@ -118,7 +118,7 @@ Faye.NodeAdapter = Faye.Class({
 
     // http://groups.google.com/group/faye-users/browse_thread/thread/4a01bb7d25d3636a
     if (requestMethod === 'OPTIONS' || request.headers['access-control-request-method'] === 'POST')
-      return this._handleOptions(response);
+      return this._handleOptions(request, response);
 
     if (Faye.EventSource.isEventSource(request))
       return this.handleEventSource(request, response);
@@ -232,14 +232,22 @@ Faye.NodeAdapter = Faye.Class({
     };
   },
 
-  _handleOptions: function(response) {
+  _handleOptions: function(request, response) {
     var headers = {
       'Access-Control-Allow-Credentials': 'false',
-      'Access-Control-Allow-Headers':     'Accept, Content-Type, Pragma, X-Requested-With',
+      'Access-Control-Allow-Headers':     'Authorization, Accept, Content-Type, Pragma, X-Requested-With',
       'Access-Control-Allow-Methods':     'POST, GET, PUT, DELETE, OPTIONS',
       'Access-Control-Allow-Origin':      '*',
-      'Access-Control-Max-Age':           '86400'
     };
+    if(req.headers.origin) {
+        headers['Access-Control-Allow-Origin'] =  req.headers.origin;
+    }
+    if(req.headers['access-control-request-method']) {
+        headers['Access-Control-Allow-Methods'] = req.headers['access-control-request-method'];
+    }
+    if(req.headers['access-control-request-headers']) {
+        headers['Access-Control-Allow-Headers'] = req.headers['access-control-request-headers'];
+    }
     response.writeHead(200, headers);
     response.end('');
   },

--- a/javascript/adapters/node_adapter.js
+++ b/javascript/adapters/node_adapter.js
@@ -239,14 +239,14 @@ Faye.NodeAdapter = Faye.Class({
       'Access-Control-Allow-Methods':     'POST, GET, PUT, DELETE, OPTIONS',
       'Access-Control-Allow-Origin':      '*',
     };
-    if(req.headers.origin) {
-        headers['Access-Control-Allow-Origin'] =  req.headers.origin;
+    if(request.headers.origin) {
+        headers['Access-Control-Allow-Origin'] =  request.headers.origin;
     }
-    if(req.headers['access-control-request-method']) {
-        headers['Access-Control-Allow-Methods'] = req.headers['access-control-request-method'];
+    if(request.headers['access-control-request-method']) {
+        headers['Access-Control-Allow-Methods'] = request.headers['access-control-request-method'];
     }
-    if(req.headers['access-control-request-headers']) {
-        headers['Access-Control-Allow-Headers'] = req.headers['access-control-request-headers'];
+    if(request.headers['access-control-request-headers']) {
+        headers['Access-Control-Allow-Headers'] = request.headers['access-control-request-headers'];
     }
     response.writeHead(200, headers);
     response.end('');


### PR DESCRIPTION
Documentation for browser client allows for custom headers (see http://faye.jcoglan.com/browser.html).  However, the server does not allow for custom headers in the CORS response for long-polling.   The following changes will mirror the response on the OPTIONS call to faye.