### PR TITLE
Provide entire message including channel to subscription callbacks

### DIFF
--- a/javascript/protocol/channel.js
+++ b/javascript/protocol/channel.js
@@ -116,7 +116,7 @@ Faye.extend(Faye.Channel, {
 
       for (var i = 0, n = channels.length; i < n; i++) {
         var channel = this._channels[channels[i]];
-        if (channel) channel.trigger('message', message.data);
+        if (channel) channel.trigger('message', message.data, message);
       }
     }
   })


### PR DESCRIPTION
Provide the entire message object, including channel, id, and any data added by extensions, as a second argument to subscription callbacks.

This does not break the API in any way, and mirrors the data provided to extensions.

This fixes issue #119
