### PR TITLE
Add channel to subscribe callback. Useful when subscribing to several channels

### DIFF
--- a/javascript/protocol/channel.js
+++ b/javascript/protocol/channel.js
@@ -116,7 +116,7 @@ Faye.extend(Faye.Channel, {
 
       for (var i = 0, n = channels.length; i < n; i++) {
         var channel = this._channels[channels[i]];
-        if (channel) channel.trigger('message', message.data);
+        if (channel) channel.trigger('message', message.data, message.channel);
       }
     }
   })

--- a/lib/faye/protocol/channel.rb
+++ b/lib/faye/protocol/channel.rb
@@ -114,7 +114,7 @@ module Faye
         channels = Channel.expand(message['channel'])
         channels.each do |name|
           channel = @channels[name]
-          channel.trigger(:message, message['data']) if channel
+          channel.trigger(:message, message['data'], message['channel']) if channel
         end
       end
     end

--- a/spec/javascript/client_spec.js
+++ b/spec/javascript/client_spec.js
@@ -337,11 +337,12 @@ JS.ENV.ClientSpec = JS.Test.describe("Client", function() { with(this) {
         }})
 
         it("sets up a listener for the subscribed channel", function(resume) { with(this) {
-          var message
-          client.subscribe("/foo/*", function(m) { message = m }).then(function() {
+          var message, channel
+          client.subscribe("/foo/*", function(m, c) { message = m; channel = c }).then(function() {
             resume(function() {
               client._receiveMessage({channel: "/foo/bar", data: "hi"})
               assertEqual( "hi", message )
+              assertEqual( "/foo/bar", channel )
             })
           })
         }})


### PR DESCRIPTION
After using faye quite a bit, I've been several times in the situation where I subscribe with globbing or to several channels and I need to know on which channel the message has been sent.

This PR exposes this information to the callback passed to the subscribe method so we can do stuff like :

```ruby
client.subscribe '/foo/*' do |message, channel|
  puts "Received #{message} on channel #{channel}"
end
```