### PR TITLE
Make sure the initial websocket promise is rejected on error

### DIFF
--- a/javascript/transport/web_socket.js
+++ b/javascript/transport/web_socket.js
@@ -62,15 +62,13 @@ Faye.Transport.WebSocket = Faye.extend(Faye.Class(Faye.Transport, {
       delete self._socket;
       self._state = self.UNCONNECTED;
       self.removeTimeout('ping');
-      self.setDeferredStatus('unknown');
 
       var pending = self._pending ? self._pending.toArray() : [];
       delete self._pending;
 
-      if (wasConnected) {
-        self._handleError(pending, true);
-      } else if (self._everConnected) {
-        self._handleError(pending);
+      if (wasConnected || self._everConnected) {
+        self.setDeferredStatus('unknown');
+        self._handleError(pending, wasConnected);
       } else {
         self.setDeferredStatus('failed');
       }


### PR DESCRIPTION
We currently have a Faye system running in production has [issues](https://github.com/faye/permessage-deflate-ruby/pull/1) with websockets on Firefox. I noticed that FF was falling back to JSONP instead of cross-origin polling. The `errback` for the WebSocket transport's `isUsable` function was never being called. This appears to happen because when the `onerror` event is fired the deferrable state is always being set to `unknown` so the promise gets deleted without firing the error handler.

The following patch ensures the deferrable gets properly updated to the failed state so that the `isUsable` chain can continue for other transports. This change makes FF properly fall back to cross-origin polling when the websocket connection is unavailable for us, but let me know if you think it is a problematic modification.