### PR TITLE
Move endpoint parsing from Dispatcher to Client

### DIFF
--- a/javascript/protocol/client.js
+++ b/javascript/protocol/client.js
@@ -19,7 +19,7 @@ Faye.Client = Faye.Class({
 
     Faye.validateOptions(options, ['interval', 'timeout', 'endpoints', 'proxy', 'retry', 'scheduler', 'websocketExtensions', 'tls', 'ca']);
 
-    this._endpoint   = endpoint || this.DEFAULT_ENDPOINT;
+    this._endpoint   = Faye.URI.parse(endpoint || this.DEFAULT_ENDPOINT);
     this._channels   = new Faye.Channel.Set();
     this._dispatcher = new Faye.Dispatcher(this, this._endpoint, options);
 

--- a/javascript/protocol/dispatcher.js
+++ b/javascript/protocol/dispatcher.js
@@ -7,7 +7,7 @@ Faye.Dispatcher = Faye.Class({
 
   initialize: function(client, endpoint, options) {
     this._client     = client;
-    this.endpoint    = Faye.URI.parse(endpoint);
+    this.endpoint    = endpoint;
     this._alternates = options.endpoints || {};
 
     this.cookies      = Faye.Cookies && new Faye.Cookies.CookieJar();


### PR DESCRIPTION
The client keeps a reference to the endpoint for logging purposes.

However the logging will expect the endpoint to already be a parsed endpoint:

https://github.com/faye/faye/blob/master/javascript/protocol/client.js#L85

At the moment this results in log messages like:
```
include.js:878 [Faye.Client] Initiating handshake with "undefined//undefinedundefined"
```

This pull request fixes this issue.

I've assumed the dispatcher is never called directly, if so it would first have to check whether the endpoint is a string and otherwise parse the uri.