### PR TITLE
Issue with IE10 creating XHR object

### DIFF
--- a/javascript/transport/xhr.js
+++ b/javascript/transport/xhr.js
@@ -5,8 +5,14 @@ Faye.Transport.XHR = Faye.extend(Faye.Class(Faye.Transport, {
 
   request: function(messages) {
     var href = this.endpoint.href,
-        xhr  = Faye.ENV.ActiveXObject ? new ActiveXObject('Microsoft.XMLHTTP') : new XMLHttpRequest(),
+        xhr,
         self = this;
+
+    try {
+      xhr = new XMLHttpRequest();
+    } catch (e) {
+      xhr = Faye.ENV.ActiveXObject ? new ActiveXObject('Microsoft.XMLHTTP') : new XMLHttpRequest();
+    }
 
     xhr.open('POST', href, true);
     xhr.setRequestHeader('Content-Type', 'application/json');

--- a/javascript/transport/xhr.js
+++ b/javascript/transport/xhr.js
@@ -8,10 +8,13 @@ Faye.Transport.XHR = Faye.extend(Faye.Class(Faye.Transport, {
         xhr,
         self = this;
 
-    try {
+    // Prefer XMLHttpRequest over ActiveXObject if they both exist
+    if (Faye.ENV.XMLHttpRequest) {
       xhr = new XMLHttpRequest();
-    } catch (e) {
-      xhr = Faye.ENV.ActiveXObject ? new ActiveXObject('Microsoft.XMLHTTP') : new XMLHttpRequest();
+    } else if (Faye.ENV.ActiveXObject) {
+      xhr = new ActiveXObject('Microsoft.XMLHTTP');
+    } else {
+      return self._handleError(messages);
     }
 
     xhr.open('POST', href, true);


### PR DESCRIPTION
We found that IE10 has both ActiveXObject and XMLHttpRequest objects. The order of creation was to try the ActiveXObject first, then fallback to the XMLHttpRequest object. In IE10 the ActiveXObject does not have "Microsoft.XMLHTTP" and it fails to create the object.

We've found that if you try the standard object first (XMLHttpRequest), and then fall back to the ActiveXObject that it works in all modern browsers.

We've had this code working in IE9, IE10, Chrome, Firefox, and Safari.