### PR TITLE
Add support for connecting to TLS servers using SNI.

### DIFF
--- a/lib/faye/transport/http.rb
+++ b/lib/faye/transport/http.rb
@@ -48,7 +48,12 @@ module Faye
 
     def create_request(params)
       version = EventMachine::HttpRequest::VERSION.split('.')[0].to_i
-      options = {:inactivity_timeout => 0}
+      options = {
+        :inactivity_timeout => 0,
+        :tls => {
+          :sni_hostname => @endpoint.hostname
+        }
+      }
 
       if @proxy[:origin]
         uri = URI.parse(@proxy[:origin])

--- a/lib/faye/transport/web_socket.rb
+++ b/lib/faye/transport/web_socket.rb
@@ -68,8 +68,16 @@ module Faye
       url.scheme = PROTOCOLS[url.scheme]
       headers['Cookie'] = cookie unless cookie == ''
 
-      options = {:extensions => extensions, :headers => headers, :proxy => @proxy}
-      socket  = Faye::WebSocket::Client.new(url.to_s, [], options)
+      options = {
+        :extensions => extensions,
+        :headers => headers,
+        :proxy => @proxy,
+        :tls => {
+          :sni_hostname => url.hostname
+        }
+      }
+
+      socket = Faye::WebSocket::Client.new(url.to_s, [], options)
 
       socket.onopen = lambda do |*args|
         store_cookies(socket.headers['Set-Cookie'])


### PR DESCRIPTION
I noticed that I was unable to connect to the public [MessageRocket Bayeux endpoint](https://ws.messagerocket.co/ws) using Faye and after investigating I have isolated the cause to lack of [SNI](https://en.wikipedia.org/wiki/Server_Name_Indication) support in (currently released versions of) [em-http-request](https://github.com/igrigorik/em-http-request). A fix has been committed to em-http-request which will enable this behaviour by default however it hasn't been released yet, see https://github.com/igrigorik/em-http-request/issues/274 for more information.

In the mean time I have added the necessary options to the two places where we create instances of `EventMachine::HttpRequest` to enable this behaviour.  This *is* a temporary workaround, however leaving it in won't cause any harm if it's left in long-term.  When em-http-request releases `1.0.4` I'm happy to take responsibility for sending a new PR disabling this behaviour and updating Faye's dependency if you so desire.

Thanks again for Faye.