### PR TITLE
Fix outdated links to Bayeux spec

### DIFF
--- a/site/src/pages/node/extensions.haml
+++ b/site/src/pages/node/extensions.haml
@@ -128,5 +128,5 @@
     protection":/security/csrf.html since Faye allows cross-origin connections.*
 
     To write extensions you'll need to know what kinds of messages are used by
-    the Bayeux protocol; see "the specification":http://svn.cometd.com/trunk/bayeux/bayeux.html
+    the Bayeux protocol; see "the specification":https://docs.cometd.org/current/reference/#_bayeux
     for more details.

--- a/site/src/pages/ruby/extensions.haml
+++ b/site/src/pages/ruby/extensions.haml
@@ -129,5 +129,5 @@
     protection":/security/csrf.html since Faye allows cross-origin connections.*
 
     To write extensions you'll need to know what kinds of messages are used by
-    the Bayeux protocol; see "the specification":http://svn.cometd.com/trunk/bayeux/bayeux.html
+    the Bayeux protocol; see "the specification":https://docs.cometd.org/current/reference/#_bayeux
     for more details.

--- a/site/src/pages/security.haml
+++ b/site/src/pages/security.haml
@@ -29,7 +29,7 @@
 
     h4. What is Faye?
 
-    Faye is an implementation of the "Bayeux":http://svn.cometd.com/trunk/bayeux/bayeux.html
+    Faye is an implementation of the "Bayeux":https://docs.cometd.org/current/reference/#_bayeux
     protocol. Clients send messages to each other via a central server, by
     sending JSON messages over various flavours of HTTP-based transport,
     including WebSocket, EventSource, XMLHttpRequest, CORS and JSON-P. Clients


### PR DESCRIPTION
It looks like where the spec has moved! The old link, http://svn.cometd.com/trunk/bayeux/bayeux.html, appears to be offline.