### PR TITLE
Fixed: Don't use reserved keyword in dot member notation (IE8)

### DIFF
--- a/src/util/promise.js
+++ b/src/util/promise.js
@@ -28,7 +28,7 @@ Promise.prototype.then = function(onFulfilled, onRejected) {
   return next;
 };
 
-Promise.prototype.catch = function(onRejected) {
+Promise.prototype['catch'] = function(onRejected) {
   return this.then(null, onRejected);
 };
 


### PR DESCRIPTION
IE8 Doesn't like it when you use a reserved keyword in dot member notation. To avoid an "Expected identifier" error message in IE8 use bracket member selection instead.

For reference this is the same line in the [Bluebird library](https://github.com/petkaantonov/bluebird/blob/master/src/promise.js#L88) (which supports IE8)
