### PR TITLE
Fix RackAdapter#get_client

### DIFF
--- a/lib/faye/adapters/rack_adapter.rb
+++ b/lib/faye/adapters/rack_adapter.rb
@@ -69,7 +69,7 @@ module Faye
     end
 
     def get_client
-      @client ||= Client.new(@server)
+      @client ||= Client.new(@endpoint)
     end
 
     def call(env)


### PR DESCRIPTION
It was building the client the wrong way. Now it works.

Before making this change I was not able to even run it, not even once. 