### PR TITLE
Correctly parse URIs for proxies that use auth credentials

### DIFF
--- a/src/transport/node_http.js
+++ b/src/transport/node_http.js
@@ -2,7 +2,8 @@
 
 var http   = require('http'),
     https  = require('https'),
-    tunnel = require('tunnel-agent');
+    tunnel = require('tunnel-agent'),
+    url    = require('url');
 
 var Class     = require('../util/class'),
     URI       = require('../util/uri'),
@@ -22,7 +23,7 @@ var NodeHttp = extend(Class(Transport, { className: 'NodeHttp',
     var proxy = this._proxy;
     if (!proxy.origin) return;
 
-    this._proxyUri    = URI.parse(proxy.origin);
+    this._proxyUri    = url.parse(proxy.origin);
     this._proxySecure = (this.SECURE_PROTOCOLS.indexOf(this._proxyUri.protocol) >= 0);
 
     if (!this._endpointSecure) {


### PR DESCRIPTION
The URI parsing was changed from `url` to `URI` as a way to address an NPE. However the `URI` helper doesn't correctly parse basic auth which means something like `http://user:password@proxy:8888` fails with a `password@` is not a valid port number.

This change `requires` the `url` module and reverts the change to `URI` so that it can correctly parse auth details for a proxy.