### PR TITLE
Catch CSP error in web_socket to allow fallback

### DIFF
--- a/src/transport/web_socket.js
+++ b/src/transport/web_socket.js
@@ -53,7 +53,13 @@ var WebSocket = assign(Class(Transport, {
     if (this._state !== this.UNCONNECTED) return;
     this._state = this.CONNECTING;
 
-    var socket = this._createSocket();
+    var socket;
+
+    try {
+      socket = this._createSocket();
+    } catch (e) {
+      // catch CSP error to allow transport to fallback to next connType
+    }
     if (!socket) return this.setDeferredStatus('failed');
 
     var self = this;

--- a/src/transport/web_socket.js
+++ b/src/transport/web_socket.js
@@ -53,13 +53,7 @@ var WebSocket = assign(Class(Transport, {
     if (this._state !== this.UNCONNECTED) return;
     this._state = this.CONNECTING;
 
-    var socket;
-
-    try {
-      socket = this._createSocket();
-    } catch (e) {
-      // catch CSP error to allow transport to fallback to next connType
-    }
+    var socket = this._createSocket();
     if (!socket) return this.setDeferredStatus('failed');
 
     var self = this;
@@ -127,7 +121,11 @@ var WebSocket = assign(Class(Transport, {
 
     if (cookie !== '') options.headers['Cookie'] = cookie;
 
-    return ws.create(url, [], options);
+    try {
+      return ws.create(url, [], options);
+    } catch (e) {
+      // catch CSP error to allow transport to fallback to next connType
+    }
   },
 
   _ping: function() {


### PR DESCRIPTION
Fixes https://github.com/faye/faye/issues/477

When the failure occurs, the uncaught error prevents [this loop](https://github.com/jugarrit/faye/blob/master/src/transport/transport.js#L173) from completing and long-polling is never established.