### PR TITLE
Fix cors isUsable to only return true successful connection

### DIFF
--- a/src/transport/cors.js
+++ b/src/transport/cors.js
@@ -76,9 +76,20 @@ var CORS = assign(Class(Transport, {
 
     if (global.XMLHttpRequest) {
       var xhr = new XMLHttpRequest();
-      return callback.call(context, xhr.withCredentials !== undefined);
+
+      if (xhr.withCredentials !== undefined) {
+        xhr.open('POST', endpoint.href, true);
+        xhr.onload = function (e) {
+          callback.call(context, true);
+        };
+        xhr.onerror = function (e) {
+          callback.call(context, false);
+        };
+        xhr.send(null);
+      }
+    } else {
+      return callback.call(context, false);
     }
-    return callback.call(context, false);
   }
 });
 


### PR DESCRIPTION
Previously `isUsable` was returning true for the `cross-origin-long-polling` transport even if the transport is not usable.

This fix checks for usability by actually opening a connection before returning true.