### PR TITLE
Echo origin/referer in cors origin header for OPTION requests

### DIFF
--- a/src/adapters/node_adapter.js
+++ b/src/adapters/node_adapter.js
@@ -118,7 +118,7 @@ var NodeAdapter = Class({ className: 'NodeAdapter',
 
     // http://groups.google.com/group/faye-users/browse_thread/thread/4a01bb7d25d3636a
     if (requestMethod === 'OPTIONS' || request.headers['access-control-request-method'] === 'POST')
-      return this._handleOptions(response);
+      return this._handleOptions(request, response);
 
     if (EventSource.isEventSource(request))
       return this.handleEventSource(request, response);
@@ -236,12 +236,13 @@ var NodeAdapter = Class({ className: 'NodeAdapter',
     };
   },
 
-  _handleOptions: function(response) {
+  _handleOptions: function(request, response) {
+    var origin = request.headers.origin || request.headers.referer;
     var headers = {
       'Access-Control-Allow-Credentials': 'true',
       'Access-Control-Allow-Headers':     'Accept, Authorization, Content-Type, Pragma, X-Requested-With',
       'Access-Control-Allow-Methods':     'POST, GET',
-      'Access-Control-Allow-Origin':      '*',
+      'Access-Control-Allow-Origin':      origin || '*',
       'Access-Control-Max-Age':           '86400'
     };
 


### PR DESCRIPTION
Modify `OPTIONS` handler such that we echo back any incoming origin or referer header in `Access-Control-Allow-Origin`. This prevents certain content security policies from complaining about a wildcard `Access-Control-Allow-Origin`

**Context:**
Last year, we encountered this issue when clients would fall back to the `cors` transport, and we implemented the following workaround: https://github.com/faye/faye/pull/483/files which was not merged.

I've since revisited this issue, and tried implementing the approach suggested by @jcoglan [here](https://github.com/faye/faye/pull/483#issuecomment-329286396). It turns out, the suggested fix works.

Note that I *haven't* applied this same fix on the ruby side, but assuming this fix checks out I'm willing to do so.