### PR TITLE
Update transport.js

### DIFF
--- a/src/transport/transport.js
+++ b/src/transport/transport.js
@@ -118,7 +118,7 @@ var Transport = assign(Class({ className: 'Transport',
 
     if (!cookies) return '';
 
-    return array.map(cookies.getCookiesSync(url), function(cookie) {
+    return array.map(cookies.getCookiesSync(url, { allPaths: true }), function(cookie) {
       return cookie.cookieString();
     }).join('; ');
   },


### PR DESCRIPTION
when calling /meta/connect salesforce sends three cookies with two different paths.

The toughCookies API to get cookies only gets cookies with the path "/" by default.
Unless you pass an options object that asks for all paths.

jar.getCookiesSync(url, { allPaths: true });

"BrowserId=Yu1pLffTRJOxKC4WVk####;Path=/;Domain=.salesforce.com;Expires=Tue, 08-Jan-2019 17:59:00 GMT;Max-Age=5184000",
"t=!0vaFlJER5UsrfIGrfKp9YI2pARkJi5YS8O/yCf8GE+6HiX+CvWWacnC3MzF+OXsuC3USJWIP3#####==;Path=/cometd/;HttpOnly",
"BAYEUX_BROWSER=cc18-1mj9cwp47ftryjoabs1wo####;Path=/cometd/;Secure"

Without this option, only the BrowserId is included in subsequent requests. The Salesforce API requires all these cookies.