### PR TITLE
Handle message id collisions from another client in Faye::Dispatcher#handle_response

### DIFF
--- a/lib/faye/protocol/dispatcher.rb
+++ b/lib/faye/protocol/dispatcher.rb
@@ -123,9 +123,7 @@ module Faye
     private :send_envelope
 
     def handle_response(reply)
-      envelope = @envelopes.delete(reply['id'])
-
-      if reply.has_key?('successful') and envelope
+      if reply.has_key?('successful') and envelope = @envelopes.delete(reply['id'])
         envelope.scheduler.succeed!
         EventMachine.cancel_timer(envelope.timer) if envelope.timer
       end

--- a/spec/javascript/dispatcher_spec.js
+++ b/spec/javascript/dispatcher_spec.js
@@ -349,6 +349,12 @@ jstest.describe("Dispatcher", function() { with(this) {
         dispatcher.handleError({id: 1})
         dispatcher.handleResponse({id: 3})
       }})
+
+      it("handles id collisions from another client", function() { with(this) {
+        expect(client, "trigger").given("transport:down").exactly(1)
+        dispatcher.handleResponse({'id': 1})
+        dispatcher.handleError({'id': 1})
+      }})
     }})
   }})
 }})

--- a/spec/ruby/dispatcher_spec.rb
+++ b/spec/ruby/dispatcher_spec.rb
@@ -337,6 +337,12 @@ describe Faye::Dispatcher do
         @dispatcher.handle_error({'id' => 1})
         @dispatcher.handle_response({'id' => 3})
       end
+
+      it "handles id collisions from another client" do
+        expect(client).to receive(:trigger).with("transport:down").exactly(1)
+        @dispatcher.handle_response({'id' => 1})
+        @dispatcher.handle_error({'id' => 1})
+      end
     end
   end
 end


### PR DESCRIPTION
Hi,

We noticed a bug in the ruby faye client (props to @jarthod for discovering it).

We were able to see and reproduce it thanks to a benchmark launching a thousand of clients connected to the same server, all subscribing to the same channel.
One of them is picked randomly and sends a message to the channel. We then check if every client receives the message. When it's done, we repeat the process.

If we kill the server while some clients are sending a new message to `meta/connect` (because of `Faye::Client#cycle_connection` in client.rb), we end up with some client's dispatchers being in an `UP` state but not actually receiving the following messages.

After some investigation we saw that the message ids (coming from `Faye::Client#generate_message_id` in client.rb) are not uniques. It's a sequential integer.
In `Faye::Dispatcher#send_message`, when a message is sent, the enveloppe is saved in the `@envelopes` hash with the key being the message id.
When a message is received in `Faye::Dispatcher#handle_response`, the corresponding envelope (fetched thanks to the id) is deleted.
Finally, in  `Faye::Dispatcher#handle_error`, if a message can't be sent, the envelope is fetched, and if present, the dispatcher status will be set to `DOWN`.

So if a client tries to send a message with an id of 42, receives a message from another client also with an id of 42 and then is disconnected and has to handle the error response, the dispatcher status won't be set to  `DOWN` because the envelope corresponding to the id 42 would have already been (wrongfully) deleted.

Here are some logs of a similar situation (I added some info logs when `handle_response` or `handle_error` are called, with the corresponding message id):
```
D, T19:30:40.478565 #8724] DEBUG -- : [Faye::Transport::WebSocket] Client "oyz0d5lvf1vwkmfj81n5picaz0zwdxf" sending message to http://localhost:9291/faye via "websocket": {"channel":"/meta/connect","clientId":"oyz0d5lvf1vwkmfj81n5picaz0zwdxf","connectionType":"websocket","id":"4"}
D, T19:30:40.602500 #8724] DEBUG -- : [Faye::Transport::WebSocket] Client "oyz0d5lvf1vwkmfj81n5picaz0zwdxf" received from http://localhost:9291/faye via "websocket": [{"channel":"/public/37a0a4b147e419aa","data":"25","id":"4","signature":"eyJhbGciOiJIUzI1NiJ9.eyJjaGFubmVsIjoiL3B1YmxpYy8zN2EwYTRiMTQ3ZTQxOWFhIiwiY2xpZW50SWQiOiJxc3Rmb3l5NXpqOTFuZmthMTUwcG04MGkxdHQ2a2QzIiwiZXhwIjoxNTQ1Mjg3NDQwfQ.K9gkI-pBApnvyqLuxu4nlGh2oT7XlbyCLZOPfuDdFSU"}]
I, T19:30:40.602547 #8724]  INFO -- : [Faye::Dispatcher] oyz0d5lvf1vwkmfj81n5picaz0zwdxf: handle_response 4
D, T19:30:41.107099 #8724] DEBUG -- : [Faye::Transport::WebSocket] Client "oyz0d5lvf1vwkmfj81n5picaz0zwdxf" failed to send to http://localhost:9291/faye via "websocket": [{"channel":"/meta/connect","clientId":"oyz0d5lvf1vwkmfj81n5picaz0zwdxf","connectionType":"websocket","id":"4"}]
I, T19:30:41.107127 #8724]  INFO -- : [Faye::Dispatcher] oyz0d5lvf1vwkmfj81n5picaz0zwdxf: handle_error 4
```

This PR fixes this by deleting the envelope only if the reply contains the `"successful"` key. It's already handled like that in the javascript implementation:
```javascript
var envelope = this._envelopes[reply.id];

if (reply.successful !== undefined && envelope) {
  envelope.scheduler.succeed();
  delete this._envelopes[reply.id];
  global.clearTimeout(envelope.timer);
}
```