### PR TITLE
Update rack_adapter.rb

### DIFF
--- a/lib/faye/adapters/rack_adapter.rb
+++ b/lib/faye/adapters/rack_adapter.rb
@@ -187,7 +187,8 @@ module Faye
 
       hijack.write(buffer)
       hijack.flush
-      hijack.close_write
+      hijack.close_write if hijack.respond_to? :close_write
+      hijack.close if hijack.respond_to? :close
     end
 
     def handle_websocket(request)


### PR DESCRIPTION
Added conditional for the write_close method not being found when using SSL and puma together

When an incoming connection flagged as: 

```
[11] 172.24.0.1 - - [01/Sep/2019 03:42:23] "POST /faye HTTP/1.1" HIJACKED -1 0.0002
```

Came into a Faye server running behind Puma with SSL, without this patch the following error would occur when a `curl` request was sent to the server with a valid payload (payload worked over HTTP, but fails over HTTPS via Puma): 

```
faye_1   | [16] 172.24.0.1 - - [01/Sep/2019 03:45:11] "POST /faye HTTP/1.1" HIJACKED -1 0.0086
faye_1   | #<Thread:0x000055bce578f7d8@/usr/local/bundle/gems/logging-2.2.2/lib/logging/diagnostic_context.rb:471 run> terminated with exception (report_on_exception is true):
faye_1   | /usr/local/bundle/gems/faye-1.2.4/lib/faye/adapters/rack_adapter.rb:186:in `send_response': undefined method `close_write' for #<Puma::MiniSSL::Socket:0x000055bce5784d10> (NoMethodError)
faye_1   | 	from /usr/local/bundle/gems/faye-1.2.4/lib/faye/adapters/rack_adapter.rb:142:in `block (2 levels) in handle_request'
faye_1   | 	from /usr/local/bundle/gems/faye-1.2.4/lib/faye/protocol/server.rb:48:in `block in process'
faye_1   | 	from /usr/local/bundle/gems/faye-1.2.4/lib/faye/protocol/server.rb:60:in `block (3 levels) in process'
faye_1   | 	from /usr/local/bundle/gems/faye-1.2.4/lib/faye/protocol/extensible.rb:30:in `block in pipe_through_extensions'
faye_1   | 	from /usr/local/bundle/gems/faye-1.2.4/lib/faye/protocol/extensible.rb:32:in `block in pipe_through_extensions'
faye_1   | 	from /usr/local/bundle/gems/faye-1.2.4/lib/faye/protocol/extensible.rb:41:in `pipe_through_extensions'
faye_1   | 	from /usr/local/bundle/gems/faye-1.2.4/lib/faye/protocol/server.rb:57:in `block (2 levels) in process'
faye_1   | 	from /usr/local/bundle/gems/faye-1.2.4/lib/faye/protocol/server.rb:55:in `each'
faye_1   | 	from /usr/local/bundle/gems/faye-1.2.4/lib/faye/protocol/server.rb:55:in `each_with_index'
faye_1   | 	from /usr/local/bundle/gems/faye-1.2.4/lib/faye/protocol/server.rb:55:in `block in process'
faye_1   | 	from /usr/local/bundle/gems/faye-1.2.4/lib/faye/protocol/server.rb:106:in `handle'
faye_1   | 	from /usr/local/bundle/gems/faye-1.2.4/lib/faye/protocol/server.rb:67:in `block (2 levels) in process'
faye_1   | 	from /usr/local/bundle/gems/faye-1.2.4/lib/faye/protocol/extensible.rb:30:in `block in pipe_through_extensions'
faye_1   | 	from /usr/local/faye/app/lib/faye_docker/server_auth.rb:67:in `incoming'
faye_1   | 	from /usr/local/bundle/gems/faye-1.2.4/lib/faye/protocol/extensible.rb:36:in `block in pipe_through_extensions'
faye_1   | 	from /usr/local/bundle/gems/faye-1.2.4/lib/faye/protocol/extensible.rb:41:in `pipe_through_extensions'
faye_1   | 	from /usr/local/bundle/gems/faye-1.2.4/lib/faye/protocol/server.rb:66:in `block in process'
faye_1   | 	from /usr/local/bundle/gems/faye-1.2.4/lib/faye/protocol/server.rb:65:in `each'
faye_1   | 	from /usr/local/bundle/gems/faye-1.2.4/lib/faye/protocol/server.rb:65:in `process'
faye_1   | 	from /usr/local/bundle/gems/faye-1.2.4/lib/faye/adapters/rack_adapter.rb:132:in `block in handle_request'
faye_1   | 	from /usr/local/bundle/gems/eventmachine-1.2.7/lib/eventmachine.rb:978:in `block in run_deferred_callbacks'
faye_1   | 	from /usr/local/bundle/gems/eventmachine-1.2.7/lib/eventmachine.rb:975:in `times'
faye_1   | 	from /usr/local/bundle/gems/eventmachine-1.2.7/lib/eventmachine.rb:975:in `run_deferred_callbacks'
faye_1   | 	from /usr/local/bundle/gems/eventmachine-1.2.7/lib/eventmachine.rb:195:in `run_machine'
faye_1   | 	from /usr/local/bundle/gems/eventmachine-1.2.7/lib/eventmachine.rb:195:in `run'
faye_1   | 	from /usr/local/bundle/gems/faye-1.2.4/lib/faye/engines/proxy.rb:14:in `block in ensure_reactor_running!'
faye_1   | 	from /usr/local/bundle/gems/logging-2.2.2/lib/logging/diagnostic_context.rb:474:in `block in create_with_logging_context'
```

The line possibly in question in the above console log contains: 

Possible line
```
faye_1   | 	from /usr/local/faye/app/lib/faye_docker/server_auth.rb:67:in `incoming'
```

Contents:
https://github.com/amerlescucodez/faye-docker-ruby/blob/master/faye/lib/faye_docker/server_auth.rb#L67

Since this is a `NoMethodError` error I decided that a simple `if responds_to?` would be sufficient, although I am more than open to suggestions and future contributions pertaining to this package update. 