### PR TITLE
Add information about how to enable logging.

### DIFF
--- a/site/src/pages/browser.haml
+++ b/site/src/pages/browser.haml
@@ -107,3 +107,10 @@
     client automatically disconnecting like so:
 
     <pre>client.disable('autodisconnect');</pre>
+
+    h4. Logging
+
+    You can set a custom logger that will be used to collect logs from Faye. By
+    default there is no logging.
+
+    <pre>Faye.logger = window.console;</pre>


### PR DESCRIPTION
Closes #512 

I was considering adding a link to an example (https://github.com/faye/faye/blob/bcddb417e001da0ad7c3bc4d3741a31b383b1748/examples/public/index.html#L44). Not sure what is the proper way to do it in `haml` though 🤷‍♂ 

I think that the ability to set the `logger` variable works on [node clients](https://faye.jcoglan.com/node/clients.html) as well but I wasn't sure how to go about duplicating documentation.