### PR TITLE
Remove duplicate Content-Length headers that are rejected by Puma 5.6.4.

### DIFF
--- a/faye.gemspec
+++ b/faye.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name     = 'faye'
-  s.version  = '1.4.0'
+  s.version  = '1.4.1'
   s.summary  = 'Simple pub/sub messaging for the web'
   s.author   = 'James Coglan'
   s.email    = 'jcoglan@gmail.com'
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.files = %w[CHANGELOG.md LICENSE.md README.md] +
             Dir.glob('lib/**/*.rb') +
             client_files
-  
+
   s.add_dependency 'cookiejar', '>= 0.3.0'
   s.add_dependency 'em-http-request', '>= 1.1.6'
   s.add_dependency 'eventmachine', '>= 0.12.0'

--- a/lib/faye/adapters/rack_adapter.rb
+++ b/lib/faye/adapters/rack_adapter.rb
@@ -17,11 +17,6 @@ module Faye
 
     VALID_JSONP_CALLBACK = /^[a-z_\$][a-z0-9_\$]*(\.[a-z_\$][a-z0-9_\$]*)*$/i
 
-    # This header is passed by Rack::Proxy during testing. Rack::Proxy seems to
-    # set content-length for you, and setting it in here really slows the tests
-    # down. Better suggestions welcome.
-    HTTP_X_NO_CONTENT_LENGTH = 'HTTP_X_NO_CONTENT_LENGTH'
-
     def initialize(app = nil, options = nil, &block)
       @app     = app if app.respond_to?(:call)
       @options = [app, options].grep(Hash).first || {}
@@ -141,7 +136,6 @@ module Faye
             headers['Content-Disposition'] = 'attachment; filename=f.txt'
           end
 
-          headers['Content-Length'] = response.bytesize.to_s unless request.env[HTTP_X_NO_CONTENT_LENGTH]
           debug('HTTP response: ?', response)
           send_response([200, headers, [response]], hijack, callback)
         end

--- a/lib/faye/adapters/static_server.rb
+++ b/lib/faye/adapters/static_server.rb
@@ -34,8 +34,6 @@ module Faye
       type = /\.js$/ =~ fullpath ? RackAdapter::TYPE_SCRIPT : RackAdapter::TYPE_JSON
       ims  = env['HTTP_IF_MODIFIED_SINCE']
 
-      no_content_length = env[RackAdapter::HTTP_X_NO_CONTENT_LENGTH]
-
       headers = {
         'ETag'          => cache[:digest],
         'Last-Modified' => cache[:mtime].httpdate
@@ -46,7 +44,6 @@ module Faye
       elsif ims and cache[:mtime] <= Time.httpdate(ims)
         [304, headers, ['']]
       else
-        headers['Content-Length'] = cache[:content].bytesize.to_s unless no_content_length
         headers.update(type)
         [200, headers, [cache[:content]]]
       end

--- a/lib/faye/protocol/client.rb
+++ b/lib/faye/protocol/client.rb
@@ -1,3 +1,4 @@
+
 module Faye
   class Client
 
@@ -67,7 +68,6 @@ module Faye
       return if @state != UNCONNECTED
 
       @state = CONNECTING
-
       info('Initiating handshake with ?', @dispatcher.endpoint.to_s)
       @dispatcher.select_transport(MANDATORY_CONNECTION_TYPES)
 

--- a/lib/faye/transport/http.rb
+++ b/lib/faye/transport/http.rb
@@ -30,7 +30,6 @@ module Faye
 
     def build_params(content)
       headers = {
-        'Content-Length' => content.bytesize,
         'Content-Type'   => 'application/json',
         'Host'           => @endpoint.host + (@endpoint.port ? ":#{ @endpoint.port }" : '')
       }

--- a/spec/ruby/server_proxy.rb
+++ b/spec/ruby/server_proxy.rb
@@ -43,7 +43,6 @@ class ServerProxy < Rack::Proxy
   def rewrite_env(env)
     env['HTTP_HOST'] = HOST
     env['SERVER_PORT'] = PORT
-    env[Faye::RackAdapter::HTTP_X_NO_CONTENT_LENGTH] = '1'
     env
   end
 end


### PR DESCRIPTION
This fixes the bug, rewrite it.