### PR TITLE
Add checks to prevent writing headers after a response was ended

### DIFF
--- a/src/adapters/node_adapter.js
+++ b/src/adapters/node_adapter.js
@@ -177,8 +177,18 @@ var NodeAdapter = Class({ className: 'NodeAdapter',
         headers['Content-Length'] = Buffer.from(body, 'utf8').length.toString();
 
         this.debug('HTTP response: ?', body);
-        response.writeHead(200, headers);
-        response.end(body);
+        if (!response.writableEnded) {
+          response.writeHead(200, headers);
+          response.end(body);
+        } else {
+          this.error('Attempted to add headers to writableEnded response', {
+            response: { statusCode: response.statusCode, statusMessage: response.statusMessage },
+            request: {
+              url: response.req && response.req.url,
+              method: response.req && response.req.method,
+            },
+          });
+        }
       }, this);
     } catch (error) {
       this._returnError(response, error);
@@ -297,8 +307,18 @@ var NodeAdapter = Class({ className: 'NodeAdapter',
 
     if (!response) return;
 
-    response.writeHead(400, contenttypes.TYPE_TEXT);
-    response.end('Bad request');
+    if (!response.writableEnded) {
+      response.writeHead(400, contenttypes.TYPE_TEXT);
+      response.end('Bad request');
+    } else {
+      this.error('Attempted to add headers to writableEnded response', {
+        response: { statusCode: response.statusCode, statusMessage: response.statusMessage },
+        request: {
+          url: response.req && response.req.url,
+          method: response.req && response.req.method,
+        },
+      });
+    }
   }
 });
 


### PR DESCRIPTION
Fixes unhandled exception that occurs when using Node 20
* Add checks to prevent writing headers after a response was ended
* Add error logs when attempting add headers on writableEnded