### PR TITLE
Remove deprecated Unload event

### DIFF
--- a/src/util/browser/event.js
+++ b/src/util/browser/event.js
@@ -42,9 +42,6 @@ var Event = {
   }
 };
 
-if (global.onunload !== undefined)
-  Event.on(global, 'unload', Event.detach, Event);
-
 module.exports = {
   Event: Event
 };


### PR DESCRIPTION
Fixes #547 

Removed the `Unload` hook completely and all works as expected. I tried to induce a memory leak, since that was the purpose for it and wasn't able to. Tested using the Heap Snapshot tool on Chrome.